### PR TITLE
Remove hospital copyright

### DIFF
--- a/antibiogram.html
+++ b/antibiogram.html
@@ -24,8 +24,5 @@
   <p>Consult the printed antibiogram in the resident workroom or the Tufts intranet for detailed susceptibility data.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/cranial-nerves.html
+++ b/cranial-nerves.html
@@ -16,8 +16,5 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/daily-routine.html
+++ b/daily-routine.html
@@ -168,8 +168,5 @@ bold'><o:p> </o:p></span></p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/facial-plastics.html
+++ b/facial-plastics.html
@@ -16,8 +16,5 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/facial-trauma-guide.html
+++ b/facial-trauma-guide.html
@@ -319,8 +319,5 @@ fixation.</p>
 <p>9–12 years—MMF w/ arch bars.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -2218,8 +2218,5 @@ prevertebral space</td>
 alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " /></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,5 @@
   <li><a href="map-of-tufts-medical-center.html">Map of Tufts Medical Center</a></li>
   </ul>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/laryngology.html
+++ b/laryngology.html
@@ -16,8 +16,5 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/levels-of-the-neck.html
+++ b/levels-of-the-neck.html
@@ -26,8 +26,5 @@
   <p>Understanding these levels is essential for staging head and neck cancers.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/local-rotational-flaps.html
+++ b/local-rotational-flaps.html
@@ -28,8 +28,5 @@
   <p>For complex reconstruction, consult a facial plastics reference for flap design and planning.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/map-of-tufts-medical-center.html
+++ b/map-of-tufts-medical-center.html
@@ -68,8 +68,5 @@
 </table>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/medications.html
+++ b/medications.html
@@ -59,8 +59,5 @@
     </ul>
     <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/monthly-routines.html
+++ b/monthly-routines.html
@@ -34,8 +34,5 @@ Oct, Jan, Apr, June. </p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/on-call-guide.html
+++ b/on-call-guide.html
@@ -262,8 +262,5 @@ patients.</p>
 </em></strong></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/or-instruments.html
+++ b/or-instruments.html
@@ -43,8 +43,5 @@
   </ul>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/orders-discharges-and-dictations.html
+++ b/orders-discharges-and-dictations.html
@@ -90,8 +90,5 @@ ___, the attending surgeon, was present throughout the entire case.</p>
 <p><strong>Room A182 = ENT On Call Room</strong><strong> Code=0044833</strong></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/otolaryngology-national-conference-schedule.html
+++ b/otolaryngology-national-conference-schedule.html
@@ -81,8 +81,5 @@ service with you (who make the schedule)</p>
     </form>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/otology.html
+++ b/otology.html
@@ -43,8 +43,5 @@ burr</p></li>
 </ul>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/pediatric-otolaryngology.html
+++ b/pediatric-otolaryngology.html
@@ -1079,8 +1079,5 @@ pacifier.</p></li>
 </ul>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/perioperative-aspirin-anticoagulation-guide.html
+++ b/perioperative-aspirin-anticoagulation-guide.html
@@ -219,8 +219,5 @@ services</h2>
 etc)</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/radiology-levels-of-the-neck.html
+++ b/radiology-levels-of-the-neck.html
@@ -23,8 +23,5 @@
   <p>Example cross-sectional images can be viewed at <a href="http://headneckbrainspine.com" target="_blank" rel="noopener">headneckbrainspine.com</a>.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/review-of-systems.html
+++ b/review-of-systems.html
@@ -68,8 +68,5 @@
 
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/rhinology.html
+++ b/rhinology.html
@@ -16,8 +16,5 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/rotations.html
+++ b/rotations.html
@@ -24,8 +24,5 @@ alt="C:\Users\jharb\Downloads\SGS_sizingguide.jpg" /></p>
 style="width:5.96171in;height:3.23186in" /></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/rules-of-the-game.html
+++ b/rules-of-the-game.html
@@ -109,8 +109,5 @@ has to do their bit to leave this program better off than when you came.</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -17,8 +17,5 @@
   <main class="container">
     <ul id="results"></ul>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/templates-protocols.html
+++ b/templates-protocols.html
@@ -28,8 +28,5 @@
 <p><a href="https://1drv.ms/w/s!AgoNMr1jv4esgsJIEtgeKz9gNRBggA">Resident Approval Forms for Conferences</a></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/tips.html
+++ b/tips.html
@@ -58,8 +58,5 @@ Add new exception &gt; Coverage &gt; New; Put start and end date</p>
 </ul>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/weekly-routines.html
+++ b/weekly-routines.html
@@ -47,8 +47,5 @@ sends out prelim radiology rounds list</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>

--- a/yearly-routines.html
+++ b/yearly-routines.html
@@ -48,8 +48,5 @@ access to the <span class="SpellE">boardvitals</span> website for questions</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
-  <footer>
-    <p>&copy; Tufts Medical Center</p>
-  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip out Tufts Medical Center footer text from all HTML pages

## Testing
- `grep -R "<footer>" -n`

------
https://chatgpt.com/codex/tasks/task_e_688aa789edd8832fac6d5b69fed0ad44