### PR TITLE
Fix formatting for ENT guidebook pages

### DIFF
--- a/facial-trauma-guide.html
+++ b/facial-trauma-guide.html
@@ -66,9 +66,10 @@ Follow up </h4>
 earlier so that they may be seen in clinic and taken to OR in
 appropriate time.</p>
 <blockquote>
-<p>-Adult – arrange clinic follow up in 2-3 days, plan for OR in 7-10
-days</p>
-<p>-Pediatric – clinic follow up ASAP, plan for OR in 4-6 days</p>
+<ul>
+<li>Adult – arrange clinic follow up in 2-3 days, plan for OR in 7-10 days</li>
+<li>Pediatric – clinic follow up ASAP, plan for OR in 4-6 days</li>
+</ul>
 </blockquote>
 <h4 class="unnumbered"
 id="category-1-facial-fractures-that-do-not-require-evaluation-in-the-ed">Category

--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -49,12 +49,13 @@ Andrew Scott, MD”, and not with less formal approaches like “Dr. Scott,
 PCP”</p>
 <h3 class="unnumbered" id="dr.-tracys-clinic">Dr. Tracy’s Clinic</h3>
 <p>1. Similar to Dr. O’Leary’s clinic flow</p>
-<p><span id="_Toc139824264" class="anchor"></span>Burning Mouth
-Consults: <em>Dr. O’Leary’s workup</em></p>
-<p>-Obtain lab tests: ANA, SS-A, SS-B, TSH, fasting glucose, A1c, CBC w/
-diff, ferritin, Vit B1, B2, B6, B12, folate, Mg2+, Zinc</p>
-<p>-Biopsy if visible lesion</p>
-<p>-can consider patch testing</p>
+<h3 class="unnumbered" id="burning-mouth-consults">Burning Mouth Consults</h3>
+<p><em>Dr. O’Leary’s workup</em></p>
+<ul>
+<li>Obtain lab tests: ANA, SS-A, SS-B, TSH, fasting glucose, A1c, CBC w/ diff, ferritin, Vit B1, B2, B6, B12, folate, Mg2+, Zinc</li>
+<li>Biopsy if visible lesion</li>
+<li>Consider patch testing</li>
+</ul>
 <h3 class="unnumbered" id="aphthous-ulcer-treatments">Aphthous ulcer
 treatments</h3>
 <p>triamcinolone acetonide with carboxymethylcellulose paste (Kenalog in
@@ -197,12 +198,11 @@ carotid anteriorly (Lyre sign)</p>
 <p>Vagal paraganglioma: Displaces carotid anteriorly and medially</p>
 <h3 class="unnumbered" id="salivary-glands">Salivary Glands</h3>
 <p>Innervation:</p>
-<p>-Sup. Salivary nuc → GSPN (pregang. parasymp.) [CN7] →pterygopalatine
-ganglion → lacrimal</p>
-<p>-Inf. Salivary nuc → Lesser petrosal [CN9] → Otic ganglion →
-auriculotemporal n. → parotid</p>
-<p>-Sup. Salivary nuc → Corda Tympani [CN7] → Submandibular ganglion →
-submandibular gland</p>
+<ul>
+<li>Sup. Salivary nuc → GSPN (pregang. parasymp.) [CN7] → pterygopalatine ganglion → lacrimal</li>
+<li>Inf. Salivary nuc → Lesser petrosal [CN9] → Otic ganglion → auriculotemporal n. → parotid</li>
+<li>Sup. Salivary nuc → Corda Tympani [CN7] → Submandibular ganglion → submandibular gland</li>
+</ul>
 <h3 class="unnumbered" id="melanoma">Melanoma</h3>
 <li><p>Ask about:</p>
 <li><p>Sunlight exposure, history of skin burns, family history
@@ -663,52 +663,64 @@ patients</h3>
 Check before removing any drains</p></li>
 <h3 class="unnumbered" id="generic-free-flap-tracy">Generic Free Flap
 [Tracy]</h3>
-<p>Neuro:</p>
-<p>- Continue standing tylenol through DHT</p>
-<p>- Continue oxycodone through DHT for severe pain, IV dilaudid for
-breakthrough pain</p>
-<p>- No NSAIDs until POD#7</p>
-<p> </p>
-<p>HEENT:</p>
-<p>- Start peridex swabs TID </p>
-<p>- Continue Q1H flap checks for total 48 hours</p>
-<p>- Then q2h flap checks for 24 hours</p>
-<p>- ENT resident flap checks BID</p>
-<p>- Strict NPO, no use of oral swabs unless for medication</p>
-<p>- No circumferential neck ties</p>
-<p>CV:</p>
-<p>- MAP goal &gt;60</p>
-<p>- avoid pressors as much as possible, please give fluid boluses or
-transfuse with RBC if hypotensive</p>
-<p>RESP:</p>
-<p>- 7.0 Shiley proximal XLT trach in place with 4-point sutures, and
-superior and inferior stay sutures</p>
-<p>- In the event of decannulation, pull the stay sutures towards the
-skin to bring the trachea more superficial and replace the tracheostomy
-tube. Patient is also intubatable from above</p>
-<p>GI:</p>
-<p>- Advance tube feeds to continuous rate (impact peptide)</p>
-<p>- OK for meds via DHT</p>
-<p>- Continue bowel regimen</p>
-<p>- Continue daily electrolyte checks, replete as necessary</p>
-<p>- STRICT NPO. No swabs or ice chips.</p>
-<p>ID: </p>
-<p>- Daily CBC</p>
-<p>- S/p unasyn through 8/10</p>
-<p>- Peridex TID</p>
-<p>- Bacitracin to incisions BID</p>
-<p>GU:</p>
-<p>- Continue to monitor strict I/Os</p>
-<p>- Remove foley when able</p>
-<p>HEME:</p>
-<p>- Start prophylactic dose lovenox 40 mg QD</p>
-<p>- CBC daily</p>
-<p>MSK:</p>
-<p>- Continue to monitor leg for compartment syndrome</p>
-<p>- Obtain right leg orthotic</p>
-<p>- Wound vac in place for 5 days</p>
-<p>- Work with PT daily, OOB</p>
-<p>- PT/OT consult </p>
+<p><strong>Neuro:</strong></p>
+<ul>
+<li>Continue standing tylenol through DHT</li>
+<li>Continue oxycodone through DHT for severe pain, IV dilaudid for breakthrough pain</li>
+<li>No NSAIDs until POD#7</li>
+</ul>
+<p><strong>HEENT:</strong></p>
+<ul>
+<li>Start peridex swabs TID</li>
+<li>Continue Q1H flap checks for total 48 hours</li>
+<li>Then q2h flap checks for 24 hours</li>
+<li>ENT resident flap checks BID</li>
+<li>Strict NPO, no use of oral swabs unless for medication</li>
+<li>No circumferential neck ties</li>
+</ul>
+<p><strong>CV:</strong></p>
+<ul>
+<li>MAP goal &gt;60</li>
+<li>Avoid pressors as much as possible, please give fluid boluses or transfuse with RBC if hypotensive</li>
+</ul>
+<p><strong>RESP:</strong></p>
+<ul>
+<li>7.0 Shiley proximal XLT trach in place with 4-point sutures, and superior and inferior stay sutures</li>
+<li>In the event of decannulation, pull the stay sutures towards the skin to bring the trachea more superficial and replace the tracheostomy tube. Patient is also intubatable from above</li>
+</ul>
+<p><strong>GI:</strong></p>
+<ul>
+<li>Advance tube feeds to continuous rate (impact peptide)</li>
+<li>OK for meds via DHT</li>
+<li>Continue bowel regimen</li>
+<li>Continue daily electrolyte checks, replete as necessary</li>
+<li>STRICT NPO. No swabs or ice chips.</li>
+</ul>
+<p><strong>ID:</strong></p>
+<ul>
+<li>Daily CBC</li>
+<li>S/p unasyn through 8/10</li>
+<li>Peridex TID</li>
+<li>Bacitracin to incisions BID</li>
+</ul>
+<p><strong>GU:</strong></p>
+<ul>
+<li>Continue to monitor strict I/Os</li>
+<li>Remove foley when able</li>
+</ul>
+<p><strong>HEME:</strong></p>
+<ul>
+<li>Start prophylactic dose lovenox 40 mg QD</li>
+<li>CBC daily</li>
+</ul>
+<p><strong>MSK:</strong></p>
+<ul>
+<li>Continue to monitor leg for compartment syndrome</li>
+<li>Obtain right leg orthotic</li>
+<li>Wound vac in place for 5 days</li>
+<li>Work with PT daily, OOB</li>
+<li>PT/OT consult</li>
+</ul>
 <h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy
 <li><p>Diet: NPO</p></li>
 <li><p>Nursing:</p>
@@ -759,10 +771,10 @@ and their management</h3>
 chylomicrons. Also get serum triglycerides. Positive if TG &gt;100mg/dL
 if TG(in JP) &gt; TG serum or if there are any chylomicrons</p>
 <p>Low output: &lt;500cc/day:</p>
-<p>-octreotide 100 𝜇g SC Q8 or 3-6mg IV qdaily. Can cause HTN and
-gallstones.</p>
-<p>-Medium chain triglyceride diet [For tube feeds switch to
-Portagen]</p>
+<ul>
+<li>octreotide 100 𝜇g SC Q8 or 3-6mg IV qdaily. Can cause HTN and gallstones.</li>
+<li>Medium chain triglyceride diet [For tube feeds switch to Portagen]</li>
+</ul>
 <p>High output &gt;500cc/day: typically need to go to OR.</p>
 <h2 class="unnumbered" id="head-neck-staging---8th-edition">Head &amp;
 Neck Staging - 8<sup>th</sup> Edition</h2>

--- a/orders-discharges-and-dictations.html
+++ b/orders-discharges-and-dictations.html
@@ -21,19 +21,24 @@ right column write:</p>
 <p>·       Complete medication reconciliation under the Discharge-&gt;orders. Continue all home meds
 unless otherwise stated</p>
 <p>·       Order PACU pain meds if needed under red “orders” tab</p>
-<p>·       D/C instruction: Diet, activity, wound care, when to shower, follow up instructions</p>
-<p>·       Order any new outpatient meds</p>
-<p>·       Don’t forget to fill out the brief operative note if you are not able to complete the op
-note prior to leaving the OR</p>
-<p><strong>Inpatient/Bedded Outpatient Orders</strong>****</p>
-<p>·        Can use the “General Surgery Admission” order set</p>
-<p>-make sure you correctly fill out if a patient is bedded outpatient (BOP) or inpatient (ADA)</p>
-<p>·        Every patient needs orders for vital signs, I&amp;Os, and a diet order</p>
+<ul>
+<li>D/C instruction: Diet, activity, wound care, when to shower, follow up instructions</li>
+<li>Order any new outpatient meds</li>
+<li>Don’t forget to fill out the brief operative note if you are not able to complete the op note prior to leaving the OR</li>
+</ul>
+<p><strong>Inpatient/Bedded Outpatient Orders</strong></p>
+<ul>
+<li>Can use the “General Surgery Admission” order set</li>
+<li>Make sure you correctly fill out if a patient is bedded outpatient (BOP) or inpatient (ADA)</li>
+<li>Every patient needs orders for vital signs, I&amp;Os, and a diet order</li>
+</ul>
 <p><strong>Discharge Instructions (Generic)-</strong></p>
-<p>·        Diet</p>
-<p>·        Activity (no heavy lifting x2 weeks, light exercise encouraged)</p>
-<p>·        Wound care (leave bandage for 48 hr. then may shower, etc.)</p>
-<p>·        Do not drive or make important decisions while taking narcotic pain medication</p>
+<ul>
+<li>Diet</li>
+<li>Activity (no heavy lifting x2 weeks, light exercise encouraged)</li>
+<li>Wound care (leave bandage for 48 hr. then may shower, etc.)</li>
+<li>Do not drive or make important decisions while taking narcotic pain medication</li>
+</ul>
 <p>·        Follow up (MAKE THE APPOINTMENT if possible)</p>
 <p>·        Call or return to the ED if you have fevers, chills, chest pain, difficulty breathing,
 vomiting, severe diarrhea, pain not controlled by medication, or any other symptoms that are
@@ -68,17 +73,21 @@ ___, the attending surgeon, was present throughout the entire case.</p>
 <h2>Case &amp; Duty Hour Logs</h2>
 <p><strong><em>LOGGING DUTY HOURS</em></strong></p>
 <p>1. DEPARTMENT</p>
-<p>- “Department of Otolaryngology/ENT – Otolaryngology”</p>
+<ul>
+<li>“Department of Otolaryngology/ENT – Otolaryngology”</li>
+</ul>
 <p>2. CHOOSE TRAINING LOCATION</p>
 <p>3. DUTY TYPE</p>
-<p>-Call: on-call AND in-house, (weekend rounds, consults)</p>
-<p>-Home Call-Called in: phone call but did not physically come in</p>
-<p>-try to lump all phone calls into 1 period at end of call block</p>
-<p>-Home Call-Not Called in: on-call but no calls and no coming in</p>
-<p>-Regular Duty Hours: regular M-F working hours</p>
-<p>-Research: use during your research rotation, just not when you’re on call</p>
-<p>-Conference: when attending national/regional conference (ASPO, NEOS)</p>
-<p>-Vacation: use “log vacation” button, only log M-F</p>
+<ul>
+<li>Call: on-call AND in-house, (weekend rounds, consults)</li>
+<li>Home Call-Called in: phone call but did not physically come in</li>
+<li>Try to lump all phone calls into 1 period at end of call block</li>
+<li>Home Call-Not Called in: on-call but no calls and no coming in</li>
+<li>Regular Duty Hours: regular M-F working hours</li>
+<li>Research: use during your research rotation, just not when you’re on call</li>
+<li>Conference: when attending national/regional conference (ASPO, NEOS)</li>
+<li>Vacation: use “log vacation” button, only log M-F</li>
+</ul>
 <p><strong><em>LOGGING CASES</em></strong></p>
 <p>1. ACGME Case Log website</p>
 <p>2. All residents must update cases monthly</p>

--- a/pediatric-otolaryngology.html
+++ b/pediatric-otolaryngology.html
@@ -29,29 +29,28 @@ He/She was last seen on ___, at that time ___ was noted and the plan for
 the patient was ___. Today, the patient returns. Since then ___</p>
 <h4 class="unnumbered" id="section-16"></h4>
 <h4 class="unnumbered" id="need-to-ask">NEED to ASK</h4>
-<p>- Weight</p>
-<p>- Pregnancy</p>
-<p>- Birth Hx (NICU stay / Newborn hearing screen / Intubation hx how
-long; what size tube; traumatic intubation/extubation)</p>
-<p>- Siblings</p>
-<p>- Smoking Exposure</p>
-<p>- Daycare</p>
-<p>- Pets</p>
-<p>- Travel</p>
-<p>- Exposures</p>
-<p>- Last time on Antibiotics</p>
-<p>- Double course of antibiotics</p>
-<p>- # of infections in last year (2 yr; 3 yrs)</p>
-<p>- OSA hx (mouth breathing, snoring, drooling, dry mouth, daytime
-somnolence, hyperactivity, inattentiveness, day time napping,
-enuresis)</p>
-<p>- Allergy testing</p>
-<p>- Immunizations (Up to date Vaccines?)</p>
-<p>- Growth (milestones?) height / weight / head circumference</p>
-<p>o Social delay; motor skills</p>
-<p>o Speech delay</p>
-<p>- Feeding</p>
-<p>- Family hx of ear disease; ankyloglossia (paternal);</p>
+<ul>
+<li>Weight</li>
+<li>Pregnancy</li>
+<li>Birth Hx (NICU stay / Newborn hearing screen / Intubation hx how long; what size tube; traumatic intubation/extubation)</li>
+<li>Siblings</li>
+<li>Smoking Exposure</li>
+<li>Daycare</li>
+<li>Pets</li>
+<li>Travel</li>
+<li>Exposures</li>
+<li>Last time on Antibiotics</li>
+<li>Double course of antibiotics</li>
+<li># of infections in last year (2 yr; 3 yrs)</li>
+<li>OSA hx (mouth breathing, snoring, drooling, dry mouth, daytime somnolence, hyperactivity, inattentiveness, day time napping, enuresis)</li>
+<li>Allergy testing</li>
+<li>Immunizations (Up to date Vaccines?)</li>
+<li>Growth (milestones?) height / weight / head circumference</li>
+<li>Social delay; motor skills</li>
+<li>Speech delay</li>
+<li>Feeding</li>
+<li>Family hx of ear disease; ankyloglossia (paternal);</li>
+</ul>
 <h4 class="unnumbered" id="pediatric-ros">Pediatric ROS</h4>
 <p><strong>Ears: No</strong> episodes of AOM. No otorrhea or otalgia. No
 concerns for hearing loss. No difficulty with balance. No history of
@@ -130,29 +129,43 @@ ABR by 3 months old and early intervention by 6 months old.</p>
 Percholrate test (Pendred’s) isn’t used anymore,</p>
 <p>BUN/Cr- r/o Branchio-oto-renal or Alpert’s</p>
 <p>Check:</p>
-<p>-eyes</p>
-<p>Coloboma? Think CHARGE</p>
-<p>Retinal detachment? Sticker’s</p>
-<p>Hypopigmentation/heterochromia? Think Waardenberg</p>
-<p>Retinitis Pigmentosa? Ushers</p>
-<p>-genital abnormalities? Think CHARGE</p>
-<p>-extremities</p>
-<p>syndactyly + abnormal facies: think Apert, Cornelia de Lange</p>
-<p>absent radii: oromandibular limb dysgenesis</p>
-<p>-ear abnormalities</p>
-<p>Preauricular pits bilaterally? Get renal U/S to r/o
-Branchio-oto-renal</p>
-<p>Aural atresia/microtia? Goldenhar/OAV/hemifacial macrosomia – look
-for vertebral abnormalities</p>
-<p>-facial abnormalities</p>
-<p>Craniosynotosis: Crouzon’s or Aperts</p>
-<p>Broad based nose, Synophry (unibrow): think Waardenburg</p>
-<p>-palate:</p>
-<p>Sticker’s (retinal detachment, joint abnormalities</p>
-<p>Treacher Collins (abnormal facies)</p>
-<p>Oro-palato-digital syndrome (broad toes/fingers)</p>
-<p>-facial nerve paralysis: Mobius syndrome (look for club foot, CNVI
-palsy), CHARGE, 22q11del, OAV</p>
+<ul>
+<li>Eyes
+  <ul>
+    <li>Coloboma? Think CHARGE</li>
+    <li>Retinal detachment? Sticker’s</li>
+    <li>Hypopigmentation/heterochromia? Think Waardenberg</li>
+    <li>Retinitis Pigmentosa? Ushers</li>
+  </ul>
+</li>
+<li>Genital abnormalities? Think CHARGE</li>
+<li>Extremities
+  <ul>
+    <li>syndactyly + abnormal facies: think Apert, Cornelia de Lange</li>
+    <li>absent radii: oromandibular limb dysgenesis</li>
+  </ul>
+</li>
+<li>Ear abnormalities
+  <ul>
+    <li>Preauricular pits bilaterally? Get renal U/S to r/o Branchio-oto-renal</li>
+    <li>Aural atresia/microtia? Goldenhar/OAV/hemifacial macrosomia – look for vertebral abnormalities</li>
+  </ul>
+</li>
+<li>Facial abnormalities
+  <ul>
+    <li>Craniosynotosis: Crouzon’s or Aperts</li>
+    <li>Broad based nose, Synophry (unibrow): think Waardenburg</li>
+  </ul>
+</li>
+<li>Palate:
+  <ul>
+    <li>Sticker’s (retinal detachment, joint abnormalities</li>
+    <li>Treacher Collins (abnormal facies)</li>
+    <li>Oro-palato-digital syndrome (broad toes/fingers)</li>
+  </ul>
+</li>
+<li>Facial nerve paralysis: Mobius syndrome (look for club foot, CNVI palsy), CHARGE, 22q11del, OAV</li>
+</ul>
 <h3 class="unnumbered" id="pediatric-syndromes"><img
 src="media/image14.png"
 style="width:1.59792in;height:1.6375in" />Pediatric Syndromes</h3>
@@ -175,8 +188,10 @@ carotids (important for tonsillectomies)</p>
 <p>G – Genital hypoplasia</p>
 <p>E – Ear abnormalities (microtia, inner ear abnormalities)</p>
 <h3 class="unnumbered" id="cleft-lippalate">Cleft lip/palate</h3>
-<p>-FISH 22q (r/o DiGeorge)</p>
-<p>-cardiac u/s (r/o conotruncal abnormalities -&gt; DiGeorge)</p>
+<ul>
+<li>FISH 22q (r/o DiGeorge)</li>
+<li>cardiac u/s (r/o conotruncal abnormalities -&gt; DiGeorge)</li>
+</ul>
 id="timeline-for-cleft-lippalate-patients">Timeline for Cleft Lip/Palate
 patients</h4>
 <li><p>Birth: taping, lip adhesion, NAM (nasoalveolar molding),</p></li>
@@ -709,18 +724,16 @@ night until follow up</p>
 <p>Keflex until f/u (give a refill on script)</p>
 <p>HOB &gt;30 degrees. Sinus precautions. Dry ear precautions</p>
 <p>Call for fevers, chills, drainage, persistent vertigo etc</p>
-id="botox-injections-to-salivary-glands---both-mv-as">Botox injections
-to salivary glands - both MV &amp; AS</h3>
-<p>- Call pedi ultrasound to make sure they’re available and will be in
-the room at start of case</p>
-<p>- x4 1cc syringes </p>
-<p>- x4 yellow tip 27gauge needles</p>
-<p>- x1 5cc syringe filled with sterile NS. Use 18gauge needle to dilute
-botox in the 5cc sterile NS.</p>
-<p>- Draw 1cc into each of the 1cc syringes. Place 27gauge needles on
-the 4 1cc syringes</p>
-<p>- Alcohol swabs to clean skin before injections</p>
-<p>- Usually inject 1cc or 20 units/gland</p>
+<h3 class="unnumbered" id="botox-injections-to-salivary-glands-both-mv-as">Botox injections to salivary glands - both MV &amp; AS</h3>
+<ul>
+<li>Call pedi ultrasound to make sure they’re available and will be in the room at start of case</li>
+<li>x4 1cc syringes</li>
+<li>x4 yellow tip 27gauge needles</li>
+<li>x1 5cc syringe filled with sterile NS. Use 18gauge needle to dilute botox in the 5cc sterile NS.</li>
+<li>Draw 1cc into each of the 1cc syringes. Place 27gauge needles on the 4 1cc syringes</li>
+<li>Alcohol swabs to clean skin before injections</li>
+<li>Usually inject 1cc or 20 units/gland</li>
+</ul>
 <h3 class="unnumbered" id="dr-scotts-or-guide"> Dr Scott’s OR Guide</h3>
 <p>For <strong><u>Andrew Scott operative note</u></strong> you need to
 focus on FINDINGS: <strong>+/- submucus cleft, Size of Tonsils, Size of
@@ -752,30 +765,22 @@ the patient’s face. Do not release the squeeze while in the nose, as
 this could cause epistaxis and general annoyance.)</p></li>
 <li><p>Suction stomach with adult orogastric tube “Tummy time”</p></li>
 <li><p>Remove everything, you’re done!</p></li>
-id="nasal-endoscopy-casedcr-in-combo-w-ophtho---scott">Nasal endoscopy
-case/DCR in combo w/ ophtho - Scott </h3>
-<p>- Afrin-soaked pledgets</p>
-<p>- 4.0 zero degree scope (this can be obtained from airway cart, does
-not need to be sterile, ie. don’t need pedi FESS kit solely for the
-scope)</p>
-<p>- lido w/ epi with yellow tip 27gauge needle</p>
-<p>- 4.0 Vicryl TF (if suturing stent in place)</p>
-<p>- BMT kit usually adequate for equipment (alligator, Frazier tip
-suctions), also might need freer - unless planning for full DCR in which
-case FESS kit +/- drill (not sure which kind) may be necessary</p>
+<h3 class="unnumbered" id="nasal-endoscopy-casedcr-in-combo-w-ophtho-scott">Nasal endoscopy case/DCR in combo w/ ophtho - Scott</h3>
+<ul>
+<li>Afrin-soaked pledgets</li>
+<li>4.0 zero degree scope (this can be obtained from airway cart, does not need to be sterile, i.e. don’t need pedi FESS kit solely for the scope)</li>
+<li>lido w/ epi with yellow tip 27gauge needle</li>
+<li>4.0 Vicryl TF (if suturing stent in place)</li>
+<li>BMT kit usually adequate for equipment (alligator, Frazier tip suctions), also might need freer - unless planning for full DCR in which case FESS kit +/- drill (not sure which kind) may be necessary</li>
+</ul>
 <h3 class="unnumbered" id="butterfly-tympanoplasty-scott">Butterfly
 tympanoplasty – Scott</h3>
 <p>Steps:</p>
-<p>-inject canal. Make an incision on posterior tragus. Incise through
-the cartilage to anterior surface. Elevate anterior surface first. Then
-do posterior. Keep scissors bevel up (check what this means). KEEP the
-perichondrium on the cartilage</p>
-<p>-just close incision with 2 interrupted sutures to prevent a tragal
-hematoma</p>
-<p>-rim perforation. Then use cartilage, size it 2mm larger than
-perforation. Butterfly the cartilage with a #15 blade (circumferentially
-score it). The perichondrium will cause the edges to curl so it looks
-like a ear tube. Place it in the perforation.</p>
+<ul>
+<li>inject canal. Make an incision on posterior tragus. Incise through the cartilage to anterior surface. Elevate anterior surface first. Then do posterior. Keep scissors bevel up (check what this means). KEEP the perichondrium on the cartilage</li>
+<li>just close incision with 2 interrupted sutures to prevent a tragal hematoma</li>
+<li>rim perforation. Then use cartilage, size it 2mm larger than perforation. Butterfly the cartilage with a #15 blade (circumferentially score it). The perichondrium will cause the edges to curl so it looks like a ear tube. Place it in the perforation.</li>
+</ul>
 id="pediatric-otolaryngology-post-op-guide">Pediatric Otolaryngology –
 Post Op Guide</h2>
 <li><p>Pediatric hospitalist consult is MANDATORY for all children under

--- a/perioperative-aspirin-anticoagulation-guide.html
+++ b/perioperative-aspirin-anticoagulation-guide.html
@@ -17,21 +17,18 @@
   <main class="container">
 <h2 class="unnumbered" id="anti-platelet">ANTI PLATELET</h2>
 <p><strong>Patients with stents:</strong> ASA + P2Y12 (dual) therapy</p>
-<p>-Bare Metal Stents: must have a least 1 month uninterrupted dual
-therapy. Recommend 12.</p>
-<p>-Drug Eluding Stents: must have 6 month of uninterrupted dual
-therapy:</p>
-<p>-at the very least, keep aspirin on.</p>
+<ul>
+<li>Bare Metal Stents: must have at least 1 month uninterrupted dual therapy. Recommend 12.</li>
+<li>Drug Eluting Stents: must have 6 months of uninterrupted dual therapy</li>
+<li>At the very least, keep aspirin on.</li>
+</ul>
 <h4 class="unnumbered" id="aspirin">Aspirin</h4>
-<p>-traditionally though that need to stop for 1 week since it takes 1
-week for new platelets to mature. 50% of platelet function returns in 3
-days and 80% in 4 days</p>
-<p>-does increase risk of major bleeding and acute kidney injury. No
-benefit in preventing DVT although some conflicting evidence</p>
-<p>-definitely stop aspirin in middle ear surgery, posterior chamber of
-eye surgery, intracranial surgery, intramedullary spine, and TURP</p>
-<p>-should continue patients with bare-metal stents in last 6 weeks or
-drug eluting stents in last 12 months</p>
+<ul>
+<li>Traditionally thought that need to stop for 1 week since it takes 1 week for new platelets to mature. 50% of platelet function returns in 3 days and 80% in 4 days</li>
+<li>Does increase risk of major bleeding and acute kidney injury. No benefit in preventing DVT although some conflicting evidence</li>
+<li>Definitely stop aspirin in middle ear surgery, posterior chamber of eye surgery, intracranial surgery, intramedullary spine, and TURP</li>
+<li>Should continue patients with bare-metal stents in last 6 weeks or drug eluting stents in last 12 months</li>
+</ul>
 <h4 class="unnumbered" id="p2y12-receptor-blockers">P2Y12 receptor
 blockers</h4>
 <p>Clopidogrel (Plavix) – stop 5 days preop. Best to consult
@@ -46,11 +43,11 @@ GPIIa/IIIb inhibitors</p>
 <h4 class="unnumbered"
 id="settings-where-anticoagulation-must-be-interrupted">Settings where
 anticoagulation must be interrupted:</h4>
-<p>-recent stroke (in past month) or afib not anticoagulated in past
-month. Delay surgery if possible</p>
-<p>-recent DVT being treated with heparin who needs to undergo surgery
-and cannot get heparin afterwards. Place vena cava filter</p>
-<p>-patients with chronically high risk, use a bridging agent</p>
+<ul>
+<li>Recent stroke (in past month) or afib not anticoagulated in past month. Delay surgery if possible</li>
+<li>Recent DVT being treated with heparin who needs to undergo surgery and cannot get heparin afterwards. Place vena cava filter</li>
+<li>Patients with chronically high risk, use a bridging agent</li>
+</ul>
 <p><strong>Wafarin</strong> – stop 5 days before surgery. Vit K if INR
 &gt;1.5 [can normally restart 12-24hr postop. Wont be therapeutic for
 3days]. Bridge if recent stroke, heart valve, afib w/ 5-6 CHAD2 with
@@ -64,21 +61,23 @@ POD2-3 for high risk (consider restarting at lower dose like 110mg qday
 for 1-2 days). Peak effect only takes 2-3hrs. Can check aPTT [for
 pradaxa] or Factor Xa [for xarleto] to assess if pradaxa is cleared</p>
 <p><strong>When to bridge (typically warfarin patients).</strong></p>
-<p>-VTE or arteria embolic event in past 12 weeks. For VTE, post-op
-bridging better</p>
-<p>-mechanical mitral valve, aortic valve, stents</p>
-<p>-Afib only w/ CHADS2 score 5-6 [important, BRIDGE trial]. Bridge
-pre&amp;post op until therapeudic</p>
+<ul>
+<li>VTE or arteria embolic event in past 12 weeks. For VTE, post-op bridging better</li>
+<li>Mechanical mitral valve, aortic valve, stents</li>
+<li>Afib only w/ CHADS2 score 5-6 [important, BRIDGE trial]. Bridge pre&amp;post op until therapeutic</li>
+</ul>
 <p><strong>How to bridge</strong></p>
-<p>Choice of therapeutic LWMH [1mg/kg BID] or intermediate dose (40mg
-BID) unless in renal failure then use UFH</p>
-<p>-STOP bridging LWMH 24hrs before (skip the evening dose the night
-before surgery) and UFH ggt 4-5hrs preop</p>
-<p>-RESTART: 24-48hrs if low risk surgery. 48-72hrs if high risk.</p>
+<p>Choice of therapeutic LWMH [1mg/kg BID] or intermediate dose (40mg BID) unless in renal failure then use UFH</p>
+<ul>
+<li>STOP bridging LWMH 24hrs before (skip the evening dose the night before surgery) and UFH ggt 4-5hrs preop</li>
+<li>RESTART: 24-48hrs if low risk surgery. 48-72hrs if high risk.</li>
+</ul>
 <h4 class="unnumbered" id="how-to-reverse">How to Reverse: </h4>
-<p>-warfarin: Vit K, FFP.</p>
-<p>-heparin use protamine.</p>
-<p>-dabigatran (pradaxa) use idarucizumab (Praxbind)</p>
+<ul>
+<li>warfarin: Vit K, FFP.</li>
+<li>heparin use protamine.</li>
+<li>dabigatran (pradaxa) use idarucizumab (Praxbind)</li>
+</ul>
 <h1 class="unnumbered" id="post-op-floor-guide-troubleshooting">Post-op
 Floor Guide Troubleshooting</h1>
 <h4 class="unnumbered" id="tachycardia">Tachycardia</h4>


### PR DESCRIPTION
## Summary
- normalize bullet points in guides using `<ul>`/`<li>`
- fix headings such as "Burning Mouth Consults"
- clean up checklists in pediatric and perioperative guides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ab14313c0832fad8769af38b51f01