### PR TITLE
Nest pages by guide contents

### DIFF
--- a/facial-trauma-guide.html
+++ b/facial-trauma-guide.html
@@ -66,9 +66,10 @@ Follow up </h4>
 earlier so that they may be seen in clinic and taken to OR in
 appropriate time.</p>
 <blockquote>
-<p>-Adult – arrange clinic follow up in 2-3 days, plan for OR in 7-10
-days</p>
-<p>-Pediatric – clinic follow up ASAP, plan for OR in 4-6 days</p>
+<ul>
+<li>Adult – arrange clinic follow up in 2-3 days, plan for OR in 7-10 days</li>
+<li>Pediatric – clinic follow up ASAP, plan for OR in 4-6 days</li>
+</ul>
 </blockquote>
 <h4 class="unnumbered"
 id="category-1-facial-fractures-that-do-not-require-evaluation-in-the-ed">Category

--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -49,12 +49,13 @@ Andrew Scott, MD”, and not with less formal approaches like “Dr. Scott,
 PCP”</p>
 <h3 class="unnumbered" id="dr.-tracys-clinic">Dr. Tracy’s Clinic</h3>
 <p>1. Similar to Dr. O’Leary’s clinic flow</p>
-<p><span id="_Toc139824264" class="anchor"></span>Burning Mouth
-Consults: <em>Dr. O’Leary’s workup</em></p>
-<p>-Obtain lab tests: ANA, SS-A, SS-B, TSH, fasting glucose, A1c, CBC w/
-diff, ferritin, Vit B1, B2, B6, B12, folate, Mg2+, Zinc</p>
-<p>-Biopsy if visible lesion</p>
-<p>-can consider patch testing</p>
+<h3 class="unnumbered" id="burning-mouth-consults">Burning Mouth Consults</h3>
+<p><em>Dr. O’Leary’s workup</em></p>
+<ul>
+<li>Obtain lab tests: ANA, SS-A, SS-B, TSH, fasting glucose, A1c, CBC w/ diff, ferritin, Vit B1, B2, B6, B12, folate, Mg2+, Zinc</li>
+<li>Biopsy if visible lesion</li>
+<li>Consider patch testing</li>
+</ul>
 <h3 class="unnumbered" id="aphthous-ulcer-treatments">Aphthous ulcer
 treatments</h3>
 <p>triamcinolone acetonide with carboxymethylcellulose paste (Kenalog in
@@ -197,12 +198,11 @@ carotid anteriorly (Lyre sign)</p>
 <p>Vagal paraganglioma: Displaces carotid anteriorly and medially</p>
 <h3 class="unnumbered" id="salivary-glands">Salivary Glands</h3>
 <p>Innervation:</p>
-<p>-Sup. Salivary nuc → GSPN (pregang. parasymp.) [CN7] →pterygopalatine
-ganglion → lacrimal</p>
-<p>-Inf. Salivary nuc → Lesser petrosal [CN9] → Otic ganglion →
-auriculotemporal n. → parotid</p>
-<p>-Sup. Salivary nuc → Corda Tympani [CN7] → Submandibular ganglion →
-submandibular gland</p>
+<ul>
+<li>Sup. Salivary nuc → GSPN (pregang. parasymp.) [CN7] → pterygopalatine ganglion → lacrimal</li>
+<li>Inf. Salivary nuc → Lesser petrosal [CN9] → Otic ganglion → auriculotemporal n. → parotid</li>
+<li>Sup. Salivary nuc → Corda Tympani [CN7] → Submandibular ganglion → submandibular gland</li>
+</ul>
 <h3 class="unnumbered" id="melanoma">Melanoma</h3>
 <li><p>Ask about:</p>
 <li><p>Sunlight exposure, history of skin burns, family history
@@ -663,52 +663,64 @@ patients</h3>
 Check before removing any drains</p></li>
 <h3 class="unnumbered" id="generic-free-flap-tracy">Generic Free Flap
 [Tracy]</h3>
-<p>Neuro:</p>
-<p>- Continue standing tylenol through DHT</p>
-<p>- Continue oxycodone through DHT for severe pain, IV dilaudid for
-breakthrough pain</p>
-<p>- No NSAIDs until POD#7</p>
-<p> </p>
-<p>HEENT:</p>
-<p>- Start peridex swabs TID </p>
-<p>- Continue Q1H flap checks for total 48 hours</p>
-<p>- Then q2h flap checks for 24 hours</p>
-<p>- ENT resident flap checks BID</p>
-<p>- Strict NPO, no use of oral swabs unless for medication</p>
-<p>- No circumferential neck ties</p>
-<p>CV:</p>
-<p>- MAP goal &gt;60</p>
-<p>- avoid pressors as much as possible, please give fluid boluses or
-transfuse with RBC if hypotensive</p>
-<p>RESP:</p>
-<p>- 7.0 Shiley proximal XLT trach in place with 4-point sutures, and
-superior and inferior stay sutures</p>
-<p>- In the event of decannulation, pull the stay sutures towards the
-skin to bring the trachea more superficial and replace the tracheostomy
-tube. Patient is also intubatable from above</p>
-<p>GI:</p>
-<p>- Advance tube feeds to continuous rate (impact peptide)</p>
-<p>- OK for meds via DHT</p>
-<p>- Continue bowel regimen</p>
-<p>- Continue daily electrolyte checks, replete as necessary</p>
-<p>- STRICT NPO. No swabs or ice chips.</p>
-<p>ID: </p>
-<p>- Daily CBC</p>
-<p>- S/p unasyn through 8/10</p>
-<p>- Peridex TID</p>
-<p>- Bacitracin to incisions BID</p>
-<p>GU:</p>
-<p>- Continue to monitor strict I/Os</p>
-<p>- Remove foley when able</p>
-<p>HEME:</p>
-<p>- Start prophylactic dose lovenox 40 mg QD</p>
-<p>- CBC daily</p>
-<p>MSK:</p>
-<p>- Continue to monitor leg for compartment syndrome</p>
-<p>- Obtain right leg orthotic</p>
-<p>- Wound vac in place for 5 days</p>
-<p>- Work with PT daily, OOB</p>
-<p>- PT/OT consult </p>
+<p><strong>Neuro:</strong></p>
+<ul>
+<li>Continue standing tylenol through DHT</li>
+<li>Continue oxycodone through DHT for severe pain, IV dilaudid for breakthrough pain</li>
+<li>No NSAIDs until POD#7</li>
+</ul>
+<p><strong>HEENT:</strong></p>
+<ul>
+<li>Start peridex swabs TID</li>
+<li>Continue Q1H flap checks for total 48 hours</li>
+<li>Then q2h flap checks for 24 hours</li>
+<li>ENT resident flap checks BID</li>
+<li>Strict NPO, no use of oral swabs unless for medication</li>
+<li>No circumferential neck ties</li>
+</ul>
+<p><strong>CV:</strong></p>
+<ul>
+<li>MAP goal &gt;60</li>
+<li>Avoid pressors as much as possible, please give fluid boluses or transfuse with RBC if hypotensive</li>
+</ul>
+<p><strong>RESP:</strong></p>
+<ul>
+<li>7.0 Shiley proximal XLT trach in place with 4-point sutures, and superior and inferior stay sutures</li>
+<li>In the event of decannulation, pull the stay sutures towards the skin to bring the trachea more superficial and replace the tracheostomy tube. Patient is also intubatable from above</li>
+</ul>
+<p><strong>GI:</strong></p>
+<ul>
+<li>Advance tube feeds to continuous rate (impact peptide)</li>
+<li>OK for meds via DHT</li>
+<li>Continue bowel regimen</li>
+<li>Continue daily electrolyte checks, replete as necessary</li>
+<li>STRICT NPO. No swabs or ice chips.</li>
+</ul>
+<p><strong>ID:</strong></p>
+<ul>
+<li>Daily CBC</li>
+<li>S/p unasyn through 8/10</li>
+<li>Peridex TID</li>
+<li>Bacitracin to incisions BID</li>
+</ul>
+<p><strong>GU:</strong></p>
+<ul>
+<li>Continue to monitor strict I/Os</li>
+<li>Remove foley when able</li>
+</ul>
+<p><strong>HEME:</strong></p>
+<ul>
+<li>Start prophylactic dose lovenox 40 mg QD</li>
+<li>CBC daily</li>
+</ul>
+<p><strong>MSK:</strong></p>
+<ul>
+<li>Continue to monitor leg for compartment syndrome</li>
+<li>Obtain right leg orthotic</li>
+<li>Wound vac in place for 5 days</li>
+<li>Work with PT daily, OOB</li>
+<li>PT/OT consult</li>
+</ul>
 <h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy
 <li><p>Diet: NPO</p></li>
 <li><p>Nursing:</p>
@@ -759,10 +771,10 @@ and their management</h3>
 chylomicrons. Also get serum triglycerides. Positive if TG &gt;100mg/dL
 if TG(in JP) &gt; TG serum or if there are any chylomicrons</p>
 <p>Low output: &lt;500cc/day:</p>
-<p>-octreotide 100 𝜇g SC Q8 or 3-6mg IV qdaily. Can cause HTN and
-gallstones.</p>
-<p>-Medium chain triglyceride diet [For tube feeds switch to
-Portagen]</p>
+<ul>
+<li>octreotide 100 𝜇g SC Q8 or 3-6mg IV qdaily. Can cause HTN and gallstones.</li>
+<li>Medium chain triglyceride diet [For tube feeds switch to Portagen]</li>
+</ul>
 <p>High output &gt;500cc/day: typically need to go to OR.</p>
 <h2 class="unnumbered" id="head-neck-staging---8th-edition">Head &amp;
 Neck Staging - 8<sup>th</sup> Edition</h2>

--- a/index.html
+++ b/index.html
@@ -15,37 +15,57 @@
     </form>
   </header>
   <main class="container">
-  <ul>
-  <li><a href="rules-of-the-game.html">Rules of the Game</a></li>
-  <li><a href="daily-routine.html">Daily Routine</a></li>
-  <li><a href="weekly-routines.html">Weekly Routines</a></li>
-  <li><a href="monthly-routines.html">Monthly Routines</a></li>
-  <li><a href="yearly-routines.html">Yearly Routines</a></li>
-  <li><a href="tips.html">Tips</a></li>
-  <li><a href="templates-protocols.html">Templates/Protocols</a></li>
-  <li><a href="orders-discharges-and-dictations.html">Orders, Discharges, and Dictations</a></li>
-  <li><a href="otolaryngology-national-conference-schedule.html">Otolaryngology National Conference Schedule</a></li>
-  <li><a href="on-call-guide.html">On-Call Guide</a></li>
-  <li><a href="facial-trauma-guide.html">Facial Trauma Guide</a></li>
-  <li><a href="otology.html">Otology</a></li>
-  <li><a href="cranial-nerves.html">Cranial Nerves</a></li>
-  <li><a href="facial-plastics.html">Facial Plastics</a></li>
-  <li><a href="pediatric-otolaryngology.html">Pediatric Otolaryngology</a></li>
-  <li><a href="rhinology.html">Rhinology</a></li>
-  <li><a href="laryngology.html">Laryngology</a></li>
-  <li><a href="head-and-neck-surgery.html">Head and Neck Surgery</a></li>
-  <li><a href="perioperative-aspirin-anticoagulation-guide.html">PERIOPERATIVE ASPIRIN/ANTICOAGULATION GUIDE</a></li>
-  <li><a href="rotations.html">Rotations</a></li>
-  <li><a href="antibiogram.html">Antibiogram</a></li>
-  <li><a href="medications.html">Medication Dosing</a></li>
-  <li><a href="local-rotational-flaps.html">Local Rotational Flaps</a></li>
-  <li><a href="levels-of-the-neck.html">Levels of the Neck</a></li>
-  <li><a href="radiology-levels-of-the-neck.html">Radiology - Levels of the Neck</a></li>
-  <li><a href="or-instruments.html">OR Instruments</a></li>
-  <li><a href="review-of-systems.html">REVIEW OF SYSTEMS</a></li>
-  <li><a href="map-of-tufts-medical-center.html">Map of Tufts Medical Center</a></li>
-  </ul>
-</main>
+    <ul>
+      <li><a href="orientation/index.html">Orientation</a>
+        <ul>
+          <li><a href="rules-of-the-game.html">Rules of the Game</a></li>
+          <li><a href="daily-routine.html">Daily Routine</a></li>
+          <li><a href="weekly-routines.html">Weekly Routines</a></li>
+          <li><a href="monthly-routines.html">Monthly Routines</a></li>
+          <li><a href="yearly-routines.html">Yearly Routines</a></li>
+          <li><a href="tips.html">Tips</a></li>
+          <li><a href="templates-protocols.html">Templates/Protocols</a></li>
+          <li><a href="orders-discharges-and-dictations.html">Orders, Discharges, and Dictations</a></li>
+          <li><a href="orientation/case-duty-hour-logs.html">Case &amp; Duty Hour Logs</a></li>
+          <li><a href="orientation/on-call-room.html">On-Call Room</a></li>
+          <li><a href="otolaryngology-national-conference-schedule.html">Otolaryngology National Conference Schedule</a></li>
+          <li><a href="orientation/vacation-requests.html">Vacation Requests</a></li>
+        </ul>
+      </li>
+      <li><a href="on-call/index.html">On-Call</a>
+        <ul>
+          <li><a href="on-call/calls.html">Calls</a></li>
+          <li><a href="on-call/consults.html">Consults</a></li>
+          <li><a href="facial-trauma-guide.html">Facial Trauma Guide</a></li>
+        </ul>
+      </li>
+      <li>Specialties
+        <ul>
+          <li><a href="otology.html">Otology</a></li>
+          <li><a href="facial-plastics.html">Facial Plastics</a></li>
+          <li><a href="pediatric-otolaryngology.html">Pediatric Otolaryngology</a></li>
+          <li><a href="rhinology.html">Rhinology</a></li>
+          <li><a href="laryngology.html">Laryngology</a></li>
+          <li><a href="head-and-neck-surgery.html">Head and Neck Surgery</a></li>
+        </ul>
+      </li>
+      <li>Resources
+        <ul>
+          <li><a href="perioperative-aspirin-anticoagulation-guide.html">Perioperative Aspirin/Anticoagulation Guide</a></li>
+          <li><a href="rotations.html">Rotations</a></li>
+          <li><a href="antibiogram.html">Antibiogram</a></li>
+          <li><a href="medications.html">Medication Dosing</a></li>
+          <li><a href="local-rotational-flaps.html">Local Rotational Flaps</a></li>
+          <li><a href="levels-of-the-neck.html">Levels of the Neck</a></li>
+          <li><a href="radiology-levels-of-the-neck.html">Radiology - Levels of the Neck</a></li>
+          <li><a href="or-instruments.html">OR Instruments</a></li>
+          <li><a href="cranial-nerves.html">Cranial Nerves</a></li>
+          <li><a href="review-of-systems.html">Review of Systems</a></li>
+          <li><a href="map-of-tufts-medical-center.html">Map of Tufts Medical Center</a></li>
+        </ul>
+      </li>
+    </ul>
+  </main>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/on-call/calls.html
+++ b/on-call/calls.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Calls</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Calls</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+<h2 class="unnumbered" id="calls">Calls</h2>
+<h4 class="unnumbered"
+id="post-tonsillectomy-patients">Post-tonsillectomy patients</h4>
+<ul>
+<li><p><strong>Bleeding:</strong> Ask all tonsil bleeds to go to an ED.
+If sounds like a large active bleed, they go to the nearest ED,
+otherwise they come to us.</p></li>
+<li><p><strong>Fever:</strong> Fever is expected for up to 2 weeks. If
+fever continues, can consider course of azithromycin (sometimes adenoid
+bed can become infected)</p></li>
+<li><p>Neck Pain: A small amount of neck pain is expected (typically
+from suspension or the adenoidectomy). If the patient cannot move their
+neck, send patient to ED for CT to r/o Grisel’s syndrome (especially if
+patient has down syndrome)</p></li>
+<li><p>Pain: check if patient has been able to receive pain meds (often
+parents can’t get kids to drink the meds). Offer PR Tylenol to help
+catch up pain</p></li>
+</ul>
+<h4 class="unnumbered" id="section-4"></h4>
+<h4 class="unnumbered" id="post-septorhinoplasty-qa">Post
+Septorhinoplasty Q&amp;A</h4>
+<ul>
+<li><p>Duration of swelling/bruising: 7-10days. Ways to reduce: sit up,
+apply ice</p></li>
+<li><p>When can I blow nose: gentile blowing starts 1-week
+post-op</p></li>
+<li><p>When should nasal drainage stop? 2-3 days postop</p></li>
+<li><p>When can I resume sports: light exercise 2-3 weeks. Sports where
+nose could be injured (ball-sports/contact sports) 3 months.</p></li>
+<li><p>When does nasal fullness/congestion subside – few weeks to a
+month</p></li>
+<li><p>When can I return to work – probably 1 week. Sooner if they are
+up to it but need to take it easy w/ lifting and moving</p></li>
+<li><p>Can I use my CPAP post-op – No (especially if cosmetic or
+osteotomies are performed since mask sits on nose + packing is in nose).
+May be able to start after packing removed at 1-week post-op check
+(Dr. Lee is typically okay once packing comes out). Tell patients to sit
+up or discuss with sleep specialist</p></li>
+<li><p>When can I wear sunglasses: Can wear them over splint. Once
+splint comes off, if possible, try and avoid glasses on bridge of nose
+for another 1 week (especially if osteotomies done) but can wear them if
+needed – just try and take them off for small periods of time.</p></li>
+<li><p>When can I fly? 2-3 weeks post-op</p></li>
+</ul>
+<p><strong>Post-ear surgery Restrictions</strong>:</p>
+<ul>
+<li><p>Glasscock dressing: 1-2 days</p>
+<ul>
+<li>For Dr. Sillman: Glasscock/cotton bud in ear is removed after 2
+days, then ear drops started</li>
+</ul></li>
+<li><p>Sinus precautions: 2 weeks</p></li>
+<li><p>Restrictions on flying: 2-3 weeks</p></li>
+<li><p>Restriction on scuba diving: for stapedectomy - forever</p></li>
+<li><p>Dry ear precautions: 6 weeks</p></li>
+</ul>
+<h4 class="unnumbered" id="sinus-surgery-restrictions">Sinus Surgery
+Restrictions:</h4>
+<ul>
+<li><p>Sinus precautions for 2-3 weeks</p></li>
+<li><p>Avoid flying for 2-3 weeks</p></li>
+</ul>
+<h4 class="unnumbered" id="travel-restrictions">Travel
+Restrictions:</h4>
+<ul>
+<li><p>Avoid flying for:</p>
+<ol type="A">
+<li><p>Sinus surgery or septorhinoplasty — 2-3 weeks</p></li>
+<li><p>Ear surgery (except tubes) — 2-3 weeks</p></li>
+<li><p>Stapedectomy — 2 weeks for Dr. Sillman (6-8 weeks: most other
+Otologists)</p></li>
+</ol></li>
+<li><p>Avoid travelling far from hospital</p>
+<ol type="A">
+<li>Tonsillectomies: 2 weeks</li>
+</ol></li>
+</ul>
+<h4 class="unnumbered" id="post-op-precautions">Post-Op
+Precautions:</h4>
+<ul>
+<li><p><strong>Dry ear precautions:</strong></p>
+<ol type="A">
+<li><p>Before showering, coat a small piece of cotton with a tablespoon
+of Vaseline ointment. Gently insert the cotton ball into the ear canal
+and keep in for the duration of the shower.</p></li>
+<li><p>If swimming or bathing is desired, purchase earplugs and a
+headband to keep earplugs from falling out.</p></li>
+</ol></li>
+<li><p><strong>Sinus Precautions</strong>:</p>
+<ol type="A">
+<li><p>Blowing your nose: Do not pinch your nose: do not blow your nose.
+You can gently wipe your nose if needed.</p></li>
+<li><p>Sneezing: If you must sneeze, keep your mouth open and do not
+pinch your nose closed.</p></li>
+<li><p>Sucking in air/liquid: Do not drink though a straw. Do not
+smoke.</p></li>
+<li><p>Blowing out air: Do not play a wind instrument. Do not blow up
+balloons.</p></li>
+<li><p>Pushing or lifting: Do not lift or push objects weighing more
+than 20 pounds. Avoid strenuous activity. Please use soft
+softeners.</p></li>
+<li><p>Bending over: Keep your head above the level of your
+heart.</p></li>
+</ol></li>
+</ul>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/on-call/consults.html
+++ b/on-call/consults.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Consults</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Consults</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+<pre><code>    Sleep with your head slightly raised</code></pre>
+<h2 class="unnumbered" id="consults">Consults</h2>
+<h4 class="unnumbered" id="epistaxis">Epistaxis</h4>
+<ul>
+<li><p>Most bleeds stop with Afrin soaked cotton and pressure.</p></li>
+<li><p>Check for hx of malignancy, trauma, HTN, family hx, dry
+environment, cocaine use. Check the BP, coags, platelets. Find out which
+side the bleed started</p></li>
+<li><p>Bring epistaxis kit: 0-degree rigid scope,
+phenylephrine+lidocaine, pledgets, surgicel, Surgifoam, Bactroban,
+ant/post rhinorocket (7.5cm), nasal speculum, bayonet forceps, #7 &amp;
+#9 Frazier tip suction, silver nitrate cautery. Can bring thrombigel or
+ask the ED to send for Surgiflo if you want to get fancy</p></li>
+<li><p>Think posterior bleeds if the patient is post-surgical or there
+is a hx of malignancy or trauma. Also, can hide on the lateral posterior
+aspect of the middle turbinate (where the SPA comes out from behind the
+maxillary sinus) For posterior bleeds, can use:</p>
+<ol type="A">
+<li><p>10F Foley – Put into nasopharynx down to oropharynx, inflate w/
+10cc, pull until balloon wedges against choanae. Clamp or tape at nasal
+alar. Monitor for palate necrosis</p></li>
+<li><p>Epistat – put into nasopharynx. Inflate posterior balloon with
+7-10cc of sterile water. Withdraw until balloon wedges against posterior
+nasal cavity, inflate anterior balloon with 15-30cc.</p></li>
+<li><p>Ant/Posterior Rapid Rhino (7.5cm) – works well. Inflate until the
+patient can’t tolerate it anymore</p></li>
+<li><p>Rule of thumb: posterior packing and bilateral packing requires
+hospital admission and pulse ox monitoring and telemetry (its arrhythmia
+you are monitoring for)</p></li>
+</ol></li>
+<li><p>It’s never coming from both sides. If the ED has packed both
+sides, take at least one of them out.</p></li>
+</ul>
+<!-- -->
+<ul>
+<li><p>ED doctors can pack a nose. As an Otolaryngologist, when you see
+an epistaxis patient, your job is to find out where the bleeding is
+coming from and why it is happening. <strong>Find the bleeding
+source</strong></p></li>
+<li><p>Soak the lidocaine/phenylephrine neuropatty and using bayonet
+forceps, gently feed it along the floor of the nasal cavity. You should
+get about two neuropatties in. They should slide all the way back and
+not bunch up at the front. Once that is in, have the patient hold
+pressure for 5-10mins. This will likely stop/slow down most bleeds and
+numb everything up so that you can look. Use a 0-degree scope and a
+Frazier tip suction and push the anterior aspect of the neuropatties
+back bit by bit so that they are wiping the septum just before you
+visualize it. This will show you where the bleeding is coming
+from.</p></li>
+<li><p><strong>If its anterior</strong> and a vessel can be seen, use a
+silver nitrate stick to cauterize it. Make sure you dry the area before
+and after cautery with a cotton tip applicator otherwise it will drop
+down onto patients’ lips and discolor their skin.</p></li>
+<li><p><strong>If its further back (mid septum)</strong>, wrap surgicel
+around Surgifoam (add some Bactroban) and press it against the area
+that’s bleeding.</p></li>
+<li><p><strong>If it’s posterior: use a posterior pack</strong>. Pumping
+vessels posteriorly will likely need to the OR to stop. Try medializing
+the middle turbinate and looking for the vessel on the lateral posterior
+aspect of the middle turbinate where the SPA comes out.</p></li>
+<li><p><strong>If it’s an HHT patient</strong>. Surgiflo seems to work
+best. Just coat the entire nasal cavity with it.</p></li>
+</ul>
+<h4 class="unnumbered" id="section-5"></h4>
+<h4 class="unnumbered" id="ptas">PTAs</h4>
+<ul>
+<li><p>CBC w/ Diff; Rapid Strep; <u>Monospot</u></p></li>
+<li><p>Decadron 10 mg IV x 1 (only if drained or neg needle aspiration +
+&gt; neg CT for abscess;</p></li>
+<li><p>Unasyn IV or Clindamycin (PCN allergic) x1 only if CBC shows no
+&gt; atypical lymphocytes &amp; monospot is negative; then continue PO x
+&gt; 7-14 days</p></li>
+<li><p>To Drain: yankeur suction at bedside, 18-gauge needle,
+&gt;27-gauge &gt; needle, 10 mL syringe, 5 mL syringe, lidocaine with
+epi, tongue &gt; depressor, 15 blade, Kelly clamp, hurricane
+spray</p></li>
+<li><p>Hurricane spray -&gt; lido w/ epi -&gt; You can needle aspirate
+to &gt; localize the region. March down the side of the peritonsillar
+&gt; space, it can be lower than you think. When you strike gold, send
+&gt; it for culture, then do an I&amp;D w/ a #15 blade and spread with
+&gt; clamp.</p></li>
+<li><p>Low threshold to scope (unless you have a CT) to clear the airway
+as &gt; edema can track down</p></li>
+</ul>
+<h4 class="unnumbered" id="section-6"></h4>
+<h4 class="unnumbered" id="tracheostomy">Tracheostomy</h4>
+<ul>
+<li><p>Family discussion completed by primary team (you aren’t
+responsible for that talk)</p></li>
+<li><p>Coagulation</p>
+<ol type="A">
+<li><p>Platelet, H/H, INR/PTT</p></li>
+<li><p>Anticoagulation (why? Can it be shut off) – lovenox stop 24hrs
+before, heparin gtt 4-5 hours before - see anticoagulation
+guide</p></li>
+</ol></li>
+<li><p>Intubation hx (PEEP (PEEP &gt;8 makes trachs much more difficult
+– pts quickly desat, trach has higher risk of dislodging) duration,
+traumatic? Tube size? Extubation attempts, exposure)</p></li>
+<li><p><strong>Operative Steps:</strong> Place shoulder roll. mark out
+midline, hyoid, thyroid cartilage, cricoid, sternal notch. Match a 3-4cm
+incision between cricoid and sternal notch. Inject w/ lido w/ epi. Prep
+&amp; drape. Incision w/ 15 blade through platysma. Use bipolar to stop
+skin bleeders. Use sennas on superior and inferior aspects of incision
+and pull up. Everything that comes up is safe. Push down w/ curved mets
+midline open (in superior/inferior direction) a little. Don’t open to
+wide (you’ll get bleeding. Keep doing that until you see straps. Always
+look for bleeding vessels. Keep palpating for midline. Once you see
+straps. Use pickups on either side of midline raphe. Develop planes
+under straps then can retract laterally first with senns then with army
+navy. If trach dives deep, comes from above thyroid over cricoid. Can
+also use bovie to separate thyroid. Careful with FiO2 and bovie coming
+up to the trachea. Switch to bipolar if you have to use it. Push fascia
+off trachea w/ a peanut. Expose you window (2/3<sup>rd</sup> tracheal
+rings). Ask anesthesia to prepare circuit. Ask scrub tech to test cuff,
+put 10cc syringe on cuff of trach, put on obturator, get a 15 blade, ask
+anesthesia to lower cuff. Open trachea (careful not to cut cuff) by
+making two horizontal incisions over 2<sup>nd</sup> and 3<sup>rd</sup>
+tracheal rings. Widen with curved mets. Use a pickup to hold piece of
+trachea between cuts and use heavy mayos to cut the sides of the
+incision to remove window. Widen w/ trach spreaders. Ask anesthesia to
+withdraw circuit until it’s just above window then, if you have time,
+place a stay suture inferiorly and superiorly. Place trach, place inner
+cannula, inflate cuff, connect anesthesia circuit, wait for CO2 return,
+secure trach w/ 4-point sutures &amp; Velcro trach tie.</p></li>
+</ul>
+<h4 class="unnumbered" id="section-7"></h4>
+<h4 class="unnumbered" id="angioedema">Angioedema</h4>
+<ul>
+<li><p>Look for watery edema of the uvula or lip edema. Always scope to
+r/o airway edema.</p></li>
+<li><p>Labs: get complement protein C4 levels and C1-INH (low levels
+-&gt; suspect C1 esterase deficiency). Also get CBC, Chem10, LFTs, CRP,
+ESR</p></li>
+<li><p>Causes: ACE inhibitor (lisinopril), NSAIDs</p></li>
+<li><p>Time frame:</p>
+<ol type="A">
+<li><p>Histamine related - comes &amp; goes within 12 hours</p></li>
+<li><p>Lisinopril related – can take 2 days for swelling to
+decrease</p></li>
+<li><p>Hereditary angioedema – can take DAYS</p></li>
+</ol></li>
+<li><p>Rec: Racemic Epi, Heliox, IV decadron, H1/H2 blockers.</p></li>
+<li><p>If hereditary angioedema, can consider:</p>
+<ol type="A">
+<li><p>Purified C1 inhibitor concentrate (Cinryze, Berinert, or
+Ruconest).</p></li>
+<li><p>Ecallantide (Kalbitor) (a kallikrein inhibitor)</p></li>
+<li><p>Icatibant (Firazyr), a bradykinin-B2-receptor antagonist</p></li>
+</ol></li>
+<li><p>If significant airway edema, prophylactically intubate, otherwise
+admit to MICU overnight for airway monitoring and rescope in
+morning</p></li>
+<li><p>Have a game plan for intubation – speak to Anesthesia to notify
+that patient is being admitted, provide plan for intubation,
+nasotracheal, fiberoptic etc.</p></li>
+</ul>
+<h4 class="unnumbered"
+id="parotitissialadenitis">Parotitis/Sialadenitis</h4>
+<ul>
+<li>MASH: Massage, antibiotics, sialagogues (lemon drops, orange
+wedges), hydration/heat.</li>
+</ul>
+<h4 class="unnumbered" id="ear-foreign-body">Ear Foreign Body</h4>
+<ul>
+<li><p>Always ask about hearing. If there is hearing loss, r/o SNHL with
+tuning fork exam</p></li>
+<li><p>Ask the ED to perform ketamine sedation. Giving a benzo (Ativan)
+is rarely enough</p></li>
+<li><p>Get a loop curette and bend it to 45 degrees, try and get it
+behind the foreign body and pop it out</p></li>
+<li><p>If the foreign body is an organic material such as popcorn, avoid
+putting in drops as this could cause the foreign body to swell</p></li>
+</ul>
+<h4 class="unnumbered" id="fish-bone">Fish Bone</h4>
+<ul>
+<li><p>Do a fiberoptic exam. If you can’t see it, offer a thin-cut CT
+w/o contrast through the larynx</p></li>
+<li><p>If fishbone is visible, have the patient inhale 4cc of 4%
+lidocaine, use hurricane spray and a uro-jet (viscous lidocaine) to numb
+the posterior oropharynx</p></li>
+<li><p>Use the ED scope or bring a tower from clinic and get McGill
+forceps</p></li>
+<li><p>Have a nurse wrap patient’s tongue with gauze and pull it out to
+improve access.</p></li>
+<li><p>For children, its often easier to go to the OR.</p></li>
+</ul>
+<h4 class="unnumbered" id="section-8"></h4>
+<h4 class="unnumbered" id="orbital-cellulitis">Orbital Cellulitis</h4>
+<ul>
+<li><p><strong>Preseptal vs Orbital Cellulitis</strong>:</p>
+<ol type="A">
+<li>Orbital cellulitis is likely to have <strong>chemosis</strong>, pain
+with EOMI, restricted eye movement</li>
+</ol></li>
+<li><p><strong>When to drain a subperiosteal abscess?</strong> If the
+abscess volume is &lt;1250mm<sup>3</sup> can avoid OR (measure abscess
+in 3 dimensions WxDxL in</p>
+<ol start="2000" type="i">
+<li></li>
+</ol></li>
+<li><p><strong>How to tell if there is a cavernous sinus
+thrombosis</strong>: get a MRI with contrast.</p>
+<ol type="A">
+<li><p>Look at DTI/DWI (isoDTI) - if the Cavernous sinus lights up,
+strong indication for Cavernous sinus thrombosis. Look for edema. If in
+the vessels, think of thrombophlebitis.</p>
+<ol type="1">
+<li>Rule out shine through. ADC map (dDTI) should be the opposite of the
+DWI (isoDTI) if it’s true. If they are the same, this is shine through
+effect.</li>
+</ol></li>
+<li><p>On T1 post contrast- look for filling defect. Then confirm on
+DWI</p>
+<ol type="1">
+<li>1-2mm should be size of superior ophthalmic vein. Expect it to be
+dilated on both sides</li>
+</ol></li>
+</ol></li>
+</ul>
+<h4 class="unnumbered" id="section-9"></h4>
+<h4 class="unnumbered" id="airway-patients-with-stridor">Airway patients
+with stridor</h4>
+<ul>
+<li><p>Ask: onset of stridor + speed of progression. Eval for infectious
+vs inflammatory vs foreign body vs neoplastic</p></li>
+<li><p>Evaluate: O2 sat, respiratory rate, retractions, ability to lay
+supine. Stridor: insp: supraglottic/glottic. Biphasic:
+glottic/subglottic. Expiratory: trachea/bronchi. <strong>Perform
+fiberoptic exam and check airway</strong></p></li>
+<li><p>Management<strong>:</strong></p>
+<ol type="1">
+<li><p><u>Airway widely patent and mild edema, slow progression of
+symptoms</u> → observation on floor w/ O2 monitoring</p></li>
+<li><p><u>Airway patent but moderate edema (e.g. angioedema
+patients)</u> → observation in ICU</p></li>
+<li><p><u>Unable to entire airway</u> → OR for awake fiberoptic
+intubation w/ possible awake trach</p></li>
+<li><p><u>Unable to see any airway</u> → OR for awake trach</p></li>
+</ol>
+<!-- -->
+<ol type="A">
+<li><p>Surgical Airway patients</p>
+<ol type="1">
+<li><p>Alert an attending</p></li>
+<li><p>Nasal trumpet, Heliox if increased WOB</p></li>
+<li><p>Bag Mask (may not be the best) or LMA</p></li>
+<li><p>If stable, perform fiberoptic exam. If intubation needed, try and
+do in OR</p></li>
+</ol></li>
+</ol></li>
+</ul>
+<h4 class="unnumbered" id="pediatric-stridor">Pediatric Stridor</h4>
+<ul>
+<li><p>Scope with nursing and bag mask equipment available. Always ask
+the NICU RN before you even touch a kid in the NICU</p></li>
+<li><p>When you scope, scope around the nasal cannula, don’t remove
+it</p></li>
+<li><p>No reflux medications in NICU babies unless the attending clears
+it (causes NEC)</p></li>
+<li><p>DDX:</p>
+<ol type="A">
+<li><p>Laryngomalacia</p></li>
+<li><p>VF immobility: see VF immobility workup in Pedi ENT
+section</p></li>
+<li><p>Complete tracheal rings</p>
+<ol type="1">
+<li><p>Get echo, head u/s +/- MRI</p></li>
+<li><p>MBS if VF immobility</p></li>
+<li><p>Low threshold for DLB</p></li>
+</ol></li>
+</ol></li>
+</ul>
+<h4 class="unnumbered" id="transfers">Transfers</h4>
+<ul>
+<li><p>Never accept an unstable transfer.</p></li>
+<li><p>No direct admits unless one of our attendings has accepted it. In
+general, transfers go through the ED</p></li>
+</ul>
+<h4 class="unnumbered" id="admissions-from-ed-what-service">Admissions
+from ED – What service?</h4>
+<p>In general, we have adopted the same model as Orthopedics.</p>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/on-call/index.html
+++ b/on-call/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>On-Call Resources</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>On-Call Resources</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+    <ul>
+      <li><a href="../on-call-guide.html">On-Call Guide</a></li>
+      <li><a href="calls.html">Calls</a></li>
+      <li><a href="consults.html">Consults</a></li>
+      <li><a href="../facial-trauma-guide.html">Facial Trauma Guide</a></li>
+    </ul>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/orders-discharges-and-dictations.html
+++ b/orders-discharges-and-dictations.html
@@ -21,19 +21,24 @@ right column write:</p>
 <p>·       Complete medication reconciliation under the Discharge-&gt;orders. Continue all home meds
 unless otherwise stated</p>
 <p>·       Order PACU pain meds if needed under red “orders” tab</p>
-<p>·       D/C instruction: Diet, activity, wound care, when to shower, follow up instructions</p>
-<p>·       Order any new outpatient meds</p>
-<p>·       Don’t forget to fill out the brief operative note if you are not able to complete the op
-note prior to leaving the OR</p>
-<p><strong>Inpatient/Bedded Outpatient Orders</strong>****</p>
-<p>·        Can use the “General Surgery Admission” order set</p>
-<p>-make sure you correctly fill out if a patient is bedded outpatient (BOP) or inpatient (ADA)</p>
-<p>·        Every patient needs orders for vital signs, I&amp;Os, and a diet order</p>
+<ul>
+<li>D/C instruction: Diet, activity, wound care, when to shower, follow up instructions</li>
+<li>Order any new outpatient meds</li>
+<li>Don’t forget to fill out the brief operative note if you are not able to complete the op note prior to leaving the OR</li>
+</ul>
+<p><strong>Inpatient/Bedded Outpatient Orders</strong></p>
+<ul>
+<li>Can use the “General Surgery Admission” order set</li>
+<li>Make sure you correctly fill out if a patient is bedded outpatient (BOP) or inpatient (ADA)</li>
+<li>Every patient needs orders for vital signs, I&amp;Os, and a diet order</li>
+</ul>
 <p><strong>Discharge Instructions (Generic)-</strong></p>
-<p>·        Diet</p>
-<p>·        Activity (no heavy lifting x2 weeks, light exercise encouraged)</p>
-<p>·        Wound care (leave bandage for 48 hr. then may shower, etc.)</p>
-<p>·        Do not drive or make important decisions while taking narcotic pain medication</p>
+<ul>
+<li>Diet</li>
+<li>Activity (no heavy lifting x2 weeks, light exercise encouraged)</li>
+<li>Wound care (leave bandage for 48 hr. then may shower, etc.)</li>
+<li>Do not drive or make important decisions while taking narcotic pain medication</li>
+</ul>
 <p>·        Follow up (MAKE THE APPOINTMENT if possible)</p>
 <p>·        Call or return to the ED if you have fevers, chills, chest pain, difficulty breathing,
 vomiting, severe diarrhea, pain not controlled by medication, or any other symptoms that are
@@ -68,17 +73,21 @@ ___, the attending surgeon, was present throughout the entire case.</p>
 <h2>Case &amp; Duty Hour Logs</h2>
 <p><strong><em>LOGGING DUTY HOURS</em></strong></p>
 <p>1. DEPARTMENT</p>
-<p>- “Department of Otolaryngology/ENT – Otolaryngology”</p>
+<ul>
+<li>“Department of Otolaryngology/ENT – Otolaryngology”</li>
+</ul>
 <p>2. CHOOSE TRAINING LOCATION</p>
 <p>3. DUTY TYPE</p>
-<p>-Call: on-call AND in-house, (weekend rounds, consults)</p>
-<p>-Home Call-Called in: phone call but did not physically come in</p>
-<p>-try to lump all phone calls into 1 period at end of call block</p>
-<p>-Home Call-Not Called in: on-call but no calls and no coming in</p>
-<p>-Regular Duty Hours: regular M-F working hours</p>
-<p>-Research: use during your research rotation, just not when you’re on call</p>
-<p>-Conference: when attending national/regional conference (ASPO, NEOS)</p>
-<p>-Vacation: use “log vacation” button, only log M-F</p>
+<ul>
+<li>Call: on-call AND in-house, (weekend rounds, consults)</li>
+<li>Home Call-Called in: phone call but did not physically come in</li>
+<li>Try to lump all phone calls into 1 period at end of call block</li>
+<li>Home Call-Not Called in: on-call but no calls and no coming in</li>
+<li>Regular Duty Hours: regular M-F working hours</li>
+<li>Research: use during your research rotation, just not when you’re on call</li>
+<li>Conference: when attending national/regional conference (ASPO, NEOS)</li>
+<li>Vacation: use “log vacation” button, only log M-F</li>
+</ul>
 <p><strong><em>LOGGING CASES</em></strong></p>
 <p>1. ACGME Case Log website</p>
 <p>2. All residents must update cases monthly</p>

--- a/orientation/case-duty-hour-logs.html
+++ b/orientation/case-duty-hour-logs.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Case & Duty Hour Logs</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Case & Duty Hour Logs</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+    <h2>Logging Duty Hours</h2>
+    <ol>
+      <li>Department: "Department of Otolaryngology/ENT &ndash; Otolaryngology"</li>
+      <li>Choose training location</li>
+      <li>Duty type
+        <ul>
+          <li>Call: on-call and in-house</li>
+          <li>Home Call &ndash; Called in</li>
+          <li>Home Call &ndash; Not Called in</li>
+          <li>Regular Duty Hours</li>
+          <li>Research</li>
+          <li>Conference</li>
+          <li>Vacation</li>
+        </ul>
+      </li>
+    </ol>
+    <h2>Logging Cases</h2>
+    <ol>
+      <li>ACGME Case Log website</li>
+      <li>All residents must update cases monthly</li>
+    </ol>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/orientation/index.html
+++ b/orientation/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Orientation</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Orientation</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+    <ul>
+      <li><a href="../rules-of-the-game.html">Rules of the Game</a></li>
+      <li><a href="../daily-routine.html">Daily Routine</a></li>
+      <li><a href="../weekly-routines.html">Weekly Routines</a></li>
+      <li><a href="../monthly-routines.html">Monthly Routines</a></li>
+      <li><a href="../yearly-routines.html">Yearly Routines</a></li>
+      <li><a href="../tips.html">Tips</a></li>
+      <li><a href="../templates-protocols.html">Templates/Protocols</a></li>
+      <li><a href="../orders-discharges-and-dictations.html">Orders, Discharges, and Dictations</a></li>
+      <li><a href="case-duty-hour-logs.html">Case &amp; Duty Hour Logs</a></li>
+      <li><a href="on-call-room.html">On-Call Room</a></li>
+      <li><a href="../otolaryngology-national-conference-schedule.html">Otolaryngology National Conference Schedule</a></li>
+      <li><a href="vacation-requests.html">Vacation Requests</a></li>
+    </ul>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/orientation/on-call-room.html
+++ b/orientation/on-call-room.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>On-Call Room</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>On-Call Room</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+    <p>Located in the Resident Suites on Farnsworth 1st floor. Ensure your badge has access.</p>
+    <p><strong>Room A182</strong> code: <strong>0044833</strong></p>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/orientation/vacation-requests.html
+++ b/orientation/vacation-requests.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Vacation Requests</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Vacation Requests</h1>
+    <form action="../search.html" method="get" class="search-form">
+      <input type="text" name="q" placeholder="Search" required>
+      <button class="btn waves-effect waves-light" type="submit">Search</button>
+    </form>
+  </header>
+  <main class="container">
+    <ul>
+      <li>If two residents at different locations want the same week, permission from Dr. Noonan is required.</li>
+      <li>No vacation during the first 7 days of a rotation.</li>
+      <li>The PGY-3 typically covers calls over the Christmas holiday.</li>
+      <li>Tufts: provide 3&nbsp;months notice to Dr. Scott for vacations or conferences.</li>
+      <li>RIH: give 2&nbsp;months notice to Dr. Groblewski.</li>
+      <li>Brockton: give ample notice to Lori Keany. Do not expect to have the weekends before or after off.</li>
+      <li>Children's: notify Dr. Gi-Soo Lee and Alanna Boyson 2&nbsp;months in advance and coordinate with the MEEI resident.</li>
+    </ul>
+    <h3>Deadlines for submission</h3>
+    <ul>
+      <li>April 1 &ndash; requests for July to September</li>
+      <li>July 1 &ndash; requests for October to December</li>
+      <li>October 1 &ndash; requests for January to March</li>
+      <li>January 1 &ndash; requests for April to June</li>
+    </ul>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/pediatric-otolaryngology.html
+++ b/pediatric-otolaryngology.html
@@ -29,29 +29,28 @@ He/She was last seen on ___, at that time ___ was noted and the plan for
 the patient was ___. Today, the patient returns. Since then ___</p>
 <h4 class="unnumbered" id="section-16"></h4>
 <h4 class="unnumbered" id="need-to-ask">NEED to ASK</h4>
-<p>- Weight</p>
-<p>- Pregnancy</p>
-<p>- Birth Hx (NICU stay / Newborn hearing screen / Intubation hx how
-long; what size tube; traumatic intubation/extubation)</p>
-<p>- Siblings</p>
-<p>- Smoking Exposure</p>
-<p>- Daycare</p>
-<p>- Pets</p>
-<p>- Travel</p>
-<p>- Exposures</p>
-<p>- Last time on Antibiotics</p>
-<p>- Double course of antibiotics</p>
-<p>- # of infections in last year (2 yr; 3 yrs)</p>
-<p>- OSA hx (mouth breathing, snoring, drooling, dry mouth, daytime
-somnolence, hyperactivity, inattentiveness, day time napping,
-enuresis)</p>
-<p>- Allergy testing</p>
-<p>- Immunizations (Up to date Vaccines?)</p>
-<p>- Growth (milestones?) height / weight / head circumference</p>
-<p>o Social delay; motor skills</p>
-<p>o Speech delay</p>
-<p>- Feeding</p>
-<p>- Family hx of ear disease; ankyloglossia (paternal);</p>
+<ul>
+<li>Weight</li>
+<li>Pregnancy</li>
+<li>Birth Hx (NICU stay / Newborn hearing screen / Intubation hx how long; what size tube; traumatic intubation/extubation)</li>
+<li>Siblings</li>
+<li>Smoking Exposure</li>
+<li>Daycare</li>
+<li>Pets</li>
+<li>Travel</li>
+<li>Exposures</li>
+<li>Last time on Antibiotics</li>
+<li>Double course of antibiotics</li>
+<li># of infections in last year (2 yr; 3 yrs)</li>
+<li>OSA hx (mouth breathing, snoring, drooling, dry mouth, daytime somnolence, hyperactivity, inattentiveness, day time napping, enuresis)</li>
+<li>Allergy testing</li>
+<li>Immunizations (Up to date Vaccines?)</li>
+<li>Growth (milestones?) height / weight / head circumference</li>
+<li>Social delay; motor skills</li>
+<li>Speech delay</li>
+<li>Feeding</li>
+<li>Family hx of ear disease; ankyloglossia (paternal);</li>
+</ul>
 <h4 class="unnumbered" id="pediatric-ros">Pediatric ROS</h4>
 <p><strong>Ears: No</strong> episodes of AOM. No otorrhea or otalgia. No
 concerns for hearing loss. No difficulty with balance. No history of
@@ -130,29 +129,43 @@ ABR by 3 months old and early intervention by 6 months old.</p>
 Percholrate test (Pendred’s) isn’t used anymore,</p>
 <p>BUN/Cr- r/o Branchio-oto-renal or Alpert’s</p>
 <p>Check:</p>
-<p>-eyes</p>
-<p>Coloboma? Think CHARGE</p>
-<p>Retinal detachment? Sticker’s</p>
-<p>Hypopigmentation/heterochromia? Think Waardenberg</p>
-<p>Retinitis Pigmentosa? Ushers</p>
-<p>-genital abnormalities? Think CHARGE</p>
-<p>-extremities</p>
-<p>syndactyly + abnormal facies: think Apert, Cornelia de Lange</p>
-<p>absent radii: oromandibular limb dysgenesis</p>
-<p>-ear abnormalities</p>
-<p>Preauricular pits bilaterally? Get renal U/S to r/o
-Branchio-oto-renal</p>
-<p>Aural atresia/microtia? Goldenhar/OAV/hemifacial macrosomia – look
-for vertebral abnormalities</p>
-<p>-facial abnormalities</p>
-<p>Craniosynotosis: Crouzon’s or Aperts</p>
-<p>Broad based nose, Synophry (unibrow): think Waardenburg</p>
-<p>-palate:</p>
-<p>Sticker’s (retinal detachment, joint abnormalities</p>
-<p>Treacher Collins (abnormal facies)</p>
-<p>Oro-palato-digital syndrome (broad toes/fingers)</p>
-<p>-facial nerve paralysis: Mobius syndrome (look for club foot, CNVI
-palsy), CHARGE, 22q11del, OAV</p>
+<ul>
+<li>Eyes
+  <ul>
+    <li>Coloboma? Think CHARGE</li>
+    <li>Retinal detachment? Sticker’s</li>
+    <li>Hypopigmentation/heterochromia? Think Waardenberg</li>
+    <li>Retinitis Pigmentosa? Ushers</li>
+  </ul>
+</li>
+<li>Genital abnormalities? Think CHARGE</li>
+<li>Extremities
+  <ul>
+    <li>syndactyly + abnormal facies: think Apert, Cornelia de Lange</li>
+    <li>absent radii: oromandibular limb dysgenesis</li>
+  </ul>
+</li>
+<li>Ear abnormalities
+  <ul>
+    <li>Preauricular pits bilaterally? Get renal U/S to r/o Branchio-oto-renal</li>
+    <li>Aural atresia/microtia? Goldenhar/OAV/hemifacial macrosomia – look for vertebral abnormalities</li>
+  </ul>
+</li>
+<li>Facial abnormalities
+  <ul>
+    <li>Craniosynotosis: Crouzon’s or Aperts</li>
+    <li>Broad based nose, Synophry (unibrow): think Waardenburg</li>
+  </ul>
+</li>
+<li>Palate:
+  <ul>
+    <li>Sticker’s (retinal detachment, joint abnormalities</li>
+    <li>Treacher Collins (abnormal facies)</li>
+    <li>Oro-palato-digital syndrome (broad toes/fingers)</li>
+  </ul>
+</li>
+<li>Facial nerve paralysis: Mobius syndrome (look for club foot, CNVI palsy), CHARGE, 22q11del, OAV</li>
+</ul>
 <h3 class="unnumbered" id="pediatric-syndromes"><img
 src="media/image14.png"
 style="width:1.59792in;height:1.6375in" />Pediatric Syndromes</h3>
@@ -175,8 +188,10 @@ carotids (important for tonsillectomies)</p>
 <p>G – Genital hypoplasia</p>
 <p>E – Ear abnormalities (microtia, inner ear abnormalities)</p>
 <h3 class="unnumbered" id="cleft-lippalate">Cleft lip/palate</h3>
-<p>-FISH 22q (r/o DiGeorge)</p>
-<p>-cardiac u/s (r/o conotruncal abnormalities -&gt; DiGeorge)</p>
+<ul>
+<li>FISH 22q (r/o DiGeorge)</li>
+<li>cardiac u/s (r/o conotruncal abnormalities -&gt; DiGeorge)</li>
+</ul>
 id="timeline-for-cleft-lippalate-patients">Timeline for Cleft Lip/Palate
 patients</h4>
 <li><p>Birth: taping, lip adhesion, NAM (nasoalveolar molding),</p></li>
@@ -709,18 +724,16 @@ night until follow up</p>
 <p>Keflex until f/u (give a refill on script)</p>
 <p>HOB &gt;30 degrees. Sinus precautions. Dry ear precautions</p>
 <p>Call for fevers, chills, drainage, persistent vertigo etc</p>
-id="botox-injections-to-salivary-glands---both-mv-as">Botox injections
-to salivary glands - both MV &amp; AS</h3>
-<p>- Call pedi ultrasound to make sure they’re available and will be in
-the room at start of case</p>
-<p>- x4 1cc syringes </p>
-<p>- x4 yellow tip 27gauge needles</p>
-<p>- x1 5cc syringe filled with sterile NS. Use 18gauge needle to dilute
-botox in the 5cc sterile NS.</p>
-<p>- Draw 1cc into each of the 1cc syringes. Place 27gauge needles on
-the 4 1cc syringes</p>
-<p>- Alcohol swabs to clean skin before injections</p>
-<p>- Usually inject 1cc or 20 units/gland</p>
+<h3 class="unnumbered" id="botox-injections-to-salivary-glands-both-mv-as">Botox injections to salivary glands - both MV &amp; AS</h3>
+<ul>
+<li>Call pedi ultrasound to make sure they’re available and will be in the room at start of case</li>
+<li>x4 1cc syringes</li>
+<li>x4 yellow tip 27gauge needles</li>
+<li>x1 5cc syringe filled with sterile NS. Use 18gauge needle to dilute botox in the 5cc sterile NS.</li>
+<li>Draw 1cc into each of the 1cc syringes. Place 27gauge needles on the 4 1cc syringes</li>
+<li>Alcohol swabs to clean skin before injections</li>
+<li>Usually inject 1cc or 20 units/gland</li>
+</ul>
 <h3 class="unnumbered" id="dr-scotts-or-guide"> Dr Scott’s OR Guide</h3>
 <p>For <strong><u>Andrew Scott operative note</u></strong> you need to
 focus on FINDINGS: <strong>+/- submucus cleft, Size of Tonsils, Size of
@@ -752,30 +765,22 @@ the patient’s face. Do not release the squeeze while in the nose, as
 this could cause epistaxis and general annoyance.)</p></li>
 <li><p>Suction stomach with adult orogastric tube “Tummy time”</p></li>
 <li><p>Remove everything, you’re done!</p></li>
-id="nasal-endoscopy-casedcr-in-combo-w-ophtho---scott">Nasal endoscopy
-case/DCR in combo w/ ophtho - Scott </h3>
-<p>- Afrin-soaked pledgets</p>
-<p>- 4.0 zero degree scope (this can be obtained from airway cart, does
-not need to be sterile, ie. don’t need pedi FESS kit solely for the
-scope)</p>
-<p>- lido w/ epi with yellow tip 27gauge needle</p>
-<p>- 4.0 Vicryl TF (if suturing stent in place)</p>
-<p>- BMT kit usually adequate for equipment (alligator, Frazier tip
-suctions), also might need freer - unless planning for full DCR in which
-case FESS kit +/- drill (not sure which kind) may be necessary</p>
+<h3 class="unnumbered" id="nasal-endoscopy-casedcr-in-combo-w-ophtho-scott">Nasal endoscopy case/DCR in combo w/ ophtho - Scott</h3>
+<ul>
+<li>Afrin-soaked pledgets</li>
+<li>4.0 zero degree scope (this can be obtained from airway cart, does not need to be sterile, i.e. don’t need pedi FESS kit solely for the scope)</li>
+<li>lido w/ epi with yellow tip 27gauge needle</li>
+<li>4.0 Vicryl TF (if suturing stent in place)</li>
+<li>BMT kit usually adequate for equipment (alligator, Frazier tip suctions), also might need freer - unless planning for full DCR in which case FESS kit +/- drill (not sure which kind) may be necessary</li>
+</ul>
 <h3 class="unnumbered" id="butterfly-tympanoplasty-scott">Butterfly
 tympanoplasty – Scott</h3>
 <p>Steps:</p>
-<p>-inject canal. Make an incision on posterior tragus. Incise through
-the cartilage to anterior surface. Elevate anterior surface first. Then
-do posterior. Keep scissors bevel up (check what this means). KEEP the
-perichondrium on the cartilage</p>
-<p>-just close incision with 2 interrupted sutures to prevent a tragal
-hematoma</p>
-<p>-rim perforation. Then use cartilage, size it 2mm larger than
-perforation. Butterfly the cartilage with a #15 blade (circumferentially
-score it). The perichondrium will cause the edges to curl so it looks
-like a ear tube. Place it in the perforation.</p>
+<ul>
+<li>inject canal. Make an incision on posterior tragus. Incise through the cartilage to anterior surface. Elevate anterior surface first. Then do posterior. Keep scissors bevel up (check what this means). KEEP the perichondrium on the cartilage</li>
+<li>just close incision with 2 interrupted sutures to prevent a tragal hematoma</li>
+<li>rim perforation. Then use cartilage, size it 2mm larger than perforation. Butterfly the cartilage with a #15 blade (circumferentially score it). The perichondrium will cause the edges to curl so it looks like a ear tube. Place it in the perforation.</li>
+</ul>
 id="pediatric-otolaryngology-post-op-guide">Pediatric Otolaryngology –
 Post Op Guide</h2>
 <li><p>Pediatric hospitalist consult is MANDATORY for all children under

--- a/perioperative-aspirin-anticoagulation-guide.html
+++ b/perioperative-aspirin-anticoagulation-guide.html
@@ -17,21 +17,18 @@
   <main class="container">
 <h2 class="unnumbered" id="anti-platelet">ANTI PLATELET</h2>
 <p><strong>Patients with stents:</strong> ASA + P2Y12 (dual) therapy</p>
-<p>-Bare Metal Stents: must have a least 1 month uninterrupted dual
-therapy. Recommend 12.</p>
-<p>-Drug Eluding Stents: must have 6 month of uninterrupted dual
-therapy:</p>
-<p>-at the very least, keep aspirin on.</p>
+<ul>
+<li>Bare Metal Stents: must have at least 1 month uninterrupted dual therapy. Recommend 12.</li>
+<li>Drug Eluting Stents: must have 6 months of uninterrupted dual therapy</li>
+<li>At the very least, keep aspirin on.</li>
+</ul>
 <h4 class="unnumbered" id="aspirin">Aspirin</h4>
-<p>-traditionally though that need to stop for 1 week since it takes 1
-week for new platelets to mature. 50% of platelet function returns in 3
-days and 80% in 4 days</p>
-<p>-does increase risk of major bleeding and acute kidney injury. No
-benefit in preventing DVT although some conflicting evidence</p>
-<p>-definitely stop aspirin in middle ear surgery, posterior chamber of
-eye surgery, intracranial surgery, intramedullary spine, and TURP</p>
-<p>-should continue patients with bare-metal stents in last 6 weeks or
-drug eluting stents in last 12 months</p>
+<ul>
+<li>Traditionally thought that need to stop for 1 week since it takes 1 week for new platelets to mature. 50% of platelet function returns in 3 days and 80% in 4 days</li>
+<li>Does increase risk of major bleeding and acute kidney injury. No benefit in preventing DVT although some conflicting evidence</li>
+<li>Definitely stop aspirin in middle ear surgery, posterior chamber of eye surgery, intracranial surgery, intramedullary spine, and TURP</li>
+<li>Should continue patients with bare-metal stents in last 6 weeks or drug eluting stents in last 12 months</li>
+</ul>
 <h4 class="unnumbered" id="p2y12-receptor-blockers">P2Y12 receptor
 blockers</h4>
 <p>Clopidogrel (Plavix) – stop 5 days preop. Best to consult
@@ -46,11 +43,11 @@ GPIIa/IIIb inhibitors</p>
 <h4 class="unnumbered"
 id="settings-where-anticoagulation-must-be-interrupted">Settings where
 anticoagulation must be interrupted:</h4>
-<p>-recent stroke (in past month) or afib not anticoagulated in past
-month. Delay surgery if possible</p>
-<p>-recent DVT being treated with heparin who needs to undergo surgery
-and cannot get heparin afterwards. Place vena cava filter</p>
-<p>-patients with chronically high risk, use a bridging agent</p>
+<ul>
+<li>Recent stroke (in past month) or afib not anticoagulated in past month. Delay surgery if possible</li>
+<li>Recent DVT being treated with heparin who needs to undergo surgery and cannot get heparin afterwards. Place vena cava filter</li>
+<li>Patients with chronically high risk, use a bridging agent</li>
+</ul>
 <p><strong>Wafarin</strong> – stop 5 days before surgery. Vit K if INR
 &gt;1.5 [can normally restart 12-24hr postop. Wont be therapeutic for
 3days]. Bridge if recent stroke, heart valve, afib w/ 5-6 CHAD2 with
@@ -64,21 +61,23 @@ POD2-3 for high risk (consider restarting at lower dose like 110mg qday
 for 1-2 days). Peak effect only takes 2-3hrs. Can check aPTT [for
 pradaxa] or Factor Xa [for xarleto] to assess if pradaxa is cleared</p>
 <p><strong>When to bridge (typically warfarin patients).</strong></p>
-<p>-VTE or arteria embolic event in past 12 weeks. For VTE, post-op
-bridging better</p>
-<p>-mechanical mitral valve, aortic valve, stents</p>
-<p>-Afib only w/ CHADS2 score 5-6 [important, BRIDGE trial]. Bridge
-pre&amp;post op until therapeudic</p>
+<ul>
+<li>VTE or arteria embolic event in past 12 weeks. For VTE, post-op bridging better</li>
+<li>Mechanical mitral valve, aortic valve, stents</li>
+<li>Afib only w/ CHADS2 score 5-6 [important, BRIDGE trial]. Bridge pre&amp;post op until therapeutic</li>
+</ul>
 <p><strong>How to bridge</strong></p>
-<p>Choice of therapeutic LWMH [1mg/kg BID] or intermediate dose (40mg
-BID) unless in renal failure then use UFH</p>
-<p>-STOP bridging LWMH 24hrs before (skip the evening dose the night
-before surgery) and UFH ggt 4-5hrs preop</p>
-<p>-RESTART: 24-48hrs if low risk surgery. 48-72hrs if high risk.</p>
+<p>Choice of therapeutic LWMH [1mg/kg BID] or intermediate dose (40mg BID) unless in renal failure then use UFH</p>
+<ul>
+<li>STOP bridging LWMH 24hrs before (skip the evening dose the night before surgery) and UFH ggt 4-5hrs preop</li>
+<li>RESTART: 24-48hrs if low risk surgery. 48-72hrs if high risk.</li>
+</ul>
 <h4 class="unnumbered" id="how-to-reverse">How to Reverse: </h4>
-<p>-warfarin: Vit K, FFP.</p>
-<p>-heparin use protamine.</p>
-<p>-dabigatran (pradaxa) use idarucizumab (Praxbind)</p>
+<ul>
+<li>warfarin: Vit K, FFP.</li>
+<li>heparin use protamine.</li>
+<li>dabigatran (pradaxa) use idarucizumab (Praxbind)</li>
+</ul>
 <h1 class="unnumbered" id="post-op-floor-guide-troubleshooting">Post-op
 Floor Guide Troubleshooting</h1>
 <h4 class="unnumbered" id="tachycardia">Tachycardia</h4>


### PR DESCRIPTION
## Summary
- organize pages under `orientation` and `on-call` directories
- add On‑Call subpages for calls and consults
- document vacation request policy, duty logs, and on-call room
- restructure index with nested links following contents in the doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ab14313c0832fad8769af38b51f01