### PR TITLE
Remove leftover text-autospace tags

### DIFF
--- a/daily-routine.html
+++ b/daily-routine.html
@@ -22,30 +22,30 @@
   
 <h3><a name="_Toc139824162">Things to Do Before Rounds</a></h3>
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l101 level1 lfo96;
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Send Staff E-mail </span></b><span style="mso-fareast-font-family:
 Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin">(performed
 by on-call resident)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
 mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></p>
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l101 level2 lfo96;
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">A<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">A<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Overnight Consults / Calls / Admissions / Discharges requiring
 follow-up</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Sign-In Pagers on Residents In-House</span></b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin"> – “In Hospital – On Page”</span><span style='mso-fareast-font-family:
 "Calibri\,Times New Roman";mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin'><o:p></o:p></span></p>
 minor-latin">3552 – Chief</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">B<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">B<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">1699– Senior(s)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">C<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">C<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">1221/5511 – Mid Level(s)</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">D<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">D<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">1777 – Junior</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">E<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">E<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">#### - Intern</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">3.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">3.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Update List &amp; Print for Everyone </span></b><b><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 Calibri;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></b></p>
 minor-latin">On-Call (Resident, Adult Attending, &amp; Pedi Attending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
@@ -54,11 +54,11 @@ minor-latin">Room Numbers (Walk rounds order: North ascending, Floating &amp;
 Main building descending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
 minor-latin">Vitals / I&amp;Os (including drain outputs)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 <p class="MsoNormal" style="margin-left:.4in;text-indent:0in;mso-pagination:none;
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 Calibri;mso-bidi-theme-font:minor-latin'>-The last 3 JP outputs (q8hrs) should
 be written from oldest to newest (e.g. 25→15→5)<o:p></o:p></span></p>
 minor-latin">Labs / Imaging / Cultures / Path</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><span style='mso-bidi-font-size:7.0pt;mso-fareast-font-family:"Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-bidi-font-size:7.0pt;mso-fareast-font-family:"Times New Roman";
 mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;mso-bidi-font-weight:
 bold'><o:p> </o:p></span></p>
 <h3><a name="_Toc139824163"><span style='font-family:"Calibri",sans-serif;
@@ -68,7 +68,7 @@ _Toc139824163"></span><span style='font-family:"Calibri",sans-serif;mso-ascii-th
 minor-latin;mso-fareast-font-family:"Times New Roman";mso-hansi-theme-font:
 minor-latin;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></h3>
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l138 level1 lfo97;
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Update List</span></b><b><span style='mso-fareast-font-family:
 minor-latin'><o:p></o:p></span></b></p>
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l138 level2 lfo97;
@@ -77,11 +77,11 @@ descending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman
 minor-latin">Daily Hospital Course</span><span style='mso-fareast-font-family:
 minor-latin">Meds / Diet / Lines / Drains</span><span style='mso-fareast-font-family:
 minor-latin">Labs / Imaging / Cultures</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">F<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">F<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">To Do List</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">G<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">G<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Discharge Paperwork / Scripts</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
 minor-latin">Update Pathology / Trauma </span></b><b><span style='mso-fareast-font-family:
 minor-latin">Sign-out Pagers</span></b><b><span style='mso-fareast-font-family:
 minor-latin">1777 = “Out of Hospital – On Page”</span><span style='mso-fareast-font-family:
@@ -90,7 +90,7 @@ minor-latin">On-call resident = “Out of Hospital – On Page”</span><span st
 minor-latin">4100 (Chief) = “Redirect to Chief’s cell phone</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 Calibri;mso-bidi-theme-font:minor-latin'>”<o:p></o:p></span></p>
 minor-latin">All other pagers = “Out of hospital – Not Available”</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;text-autospace:none"><span style='mso-bidi-font-size:7.0pt;font-family:"Calibri Light",sans-serif;
+mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-bidi-font-size:7.0pt;font-family:"Calibri Light",sans-serif;
 mso-ascii-theme-font:major-latin;mso-fareast-font-family:"Times New Roman";
 mso-hansi-theme-font:major-latin;mso-bidi-theme-font:major-latin;mso-bidi-font-weight:
 

--- a/rules-of-the-game.html
+++ b/rules-of-the-game.html
@@ -21,30 +21,30 @@
   <main class="container">
   
 <p align="center" class="MsoNormal" style="text-align:center;mso-pagination:none;
-mso-layout-grid-align:none;text-autospace:none"><b><span style='font-size:8.0pt;
+mso-layout-grid-align:none;"><b><span style='font-size:8.0pt;
 mso-ascii-font-family:Calibri;mso-fareast-font-family:"Times New Roman";
 mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri'><o:p> </o:p></span></b></p>
 <p class="MsoNormal" style="mso-pagination:none;mso-layout-grid-align:none;
-text-autospace:none"><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
+"><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
 Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri">The goal of
 residency is avoiding<b> phone calls </b>and</span><b><span style='font-family:
 "Calibri,Times New Roman",serif;mso-fareast-font-family:"Calibri\,Times New Roman";
 mso-bidi-font-family:"Calibri\,Times New Roman"'> </span></b><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:Calibri;
 mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri">avoiding<b> pages</b></span><b><span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
 "Calibri\,Times New Roman";mso-bidi-font-family:"Calibri\,Times New Roman"'><o:p></o:p></span></b></p>
-text-autospace:none"><b><span style='mso-bidi-font-size:7.0pt;mso-ascii-font-family:
+"><b><span style='mso-bidi-font-size:7.0pt;mso-ascii-font-family:
 Calibri;mso-fareast-font-family:"Times New Roman";mso-hansi-font-family:Calibri;
 mso-bidi-font-family:Calibri'><o:p> </o:p></span></b></p>
-text-autospace:none"><b>Build your differential</b>: mistakes happen when you
+"><b>Build your differential</b>: mistakes happen when you
 prematurely close on a diagnosis. R/O the worst-case scenarios<b><span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
-text-autospace:none"><b><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
+"><b><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
 Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri">Never make
 assumptions. </span></b><b><span style='font-family:"Calibri,Times New Roman",serif;
 mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:"Calibri\,Times New Roman"'><o:p></o:p></span></b></p>
 Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri">If you <b>delegate
 work,</b> you are still responsible for following up on the result</span><span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
 "Calibri\,Times New Roman";mso-bidi-font-family:"Calibri\,Times New Roman"'><o:p></o:p></span></p>
-text-autospace:none"><span style='mso-bidi-font-size:7.0pt;mso-ascii-font-family:
+"><span style='mso-bidi-font-size:7.0pt;mso-ascii-font-family:
 mso-bidi-font-family:Calibri;mso-bidi-font-weight:bold'><o:p> </o:p></span></p>
 <p class="MsoNormal"><b>Escalate </b>any clinical changes in a patient to a
 senior resident or attending. This is not just to CYA but to avoid mistakes.


### PR DESCRIPTION
## Summary
- clean up stray `text-autospace:none` fragments in HTML pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ac4ddf640832f8c39bb4ef115e92a