### PR TITLE
Fix Dr. Dhingra heading formatting

### DIFF
--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -514,7 +514,7 @@ head of the bed and tape it in place. Ensure that the nerve monitor is
 working appropriately by tapping in the neck. Mark the neck along a
 nerve crease if possible 2-3 cm above the sternal notch. Inject with 1%
 lidocaine with epi. Prep with betadine.</p>
-<h3 class="unnumbered" id="dr.-dhingras-thyroidectomy">Dr. Dhingra’s
+<h3 class="unnumbered" id="dr.-dhingras-thyroidectomy">Dr. Dhingra’s Thyroidectomy</h3>
 <p>Inject incision in preop.</p>
 <p>Make generous incision 2 inches above the sternum then make the
 incision down past the platysma on both sides and use the Bovie to
@@ -567,7 +567,7 @@ transect half of it and do the otherside. Dump some thrombin soaked
 Gelfoam into the resected area close the straps with 3-0 Vicryl. Close
 the platysma with 4-0 Vicryl and close the wound with a subcuticular 5-0
 Monocryl.</p>
-<h3 class="unnumbered" id="dr-wein-thyroidectomy">Dr Wein
+<h3 class="unnumbered" id="dr-wein-thyroidectomy">Dr Wein Thyroidectomy</h3>
 <p>Similar set up to Dhingra’s. When you lift the upper subplatysmal
 flap, roll skin over a wet 4x8 gauze and suture to mandible with 2-0
 silk to retract it. Use 3 lone stars on lower flap. Split the straps.
@@ -575,8 +575,7 @@ Free the middle of the thyroid. Use middle finger on gauze to retract
 thyroid towards you. Use a ladyfinger to retract straps. Bipolar through
 fascia. When you approach superior pole, hug gland. Dr Wein doesn’t
 necessarily go hunting for the nerve</p>
-id="dr-wein-inspire-hypoglossal-nerve-implants">Dr Wein INSPIRE
-Hypoglossal Nerve Implants</h3>
+<h3 class="unnumbered" id="dr-wein-inspire-hypoglossal-nerve-implants">Dr Wein INSPIRE Hypoglossal Nerve Implants</h3>
 <p><strong>Set Up:</strong></p>
 <li><p>Patient rotated 180. Tube taped to the left</p></li>
 <li><p>Place shoulder roll. Tuck right arm. <u>Leave mouth

--- a/head-and-neck-surgery/or-guide.html
+++ b/head-and-neck-surgery/or-guide.html
@@ -53,7 +53,7 @@ head of the bed and tape it in place. Ensure that the nerve monitor is
 working appropriately by tapping in the neck. Mark the neck along a
 nerve crease if possible 2-3 cm above the sternal notch. Inject with 1%
 lidocaine with epi. Prep with betadine.</p>
-<h3 class="unnumbered" id="dr.-dhingras-thyroidectomy">Dr. Dhingra’s
+<h3 class="unnumbered" id="dr.-dhingras-thyroidectomy">Dr. Dhingra’s Thyroidectomy</h3>
 <p>Inject incision in preop.</p>
 <p>Make generous incision 2 inches above the sternum then make the
 incision down past the platysma on both sides and use the Bovie to
@@ -106,7 +106,7 @@ transect half of it and do the otherside. Dump some thrombin soaked
 Gelfoam into the resected area close the straps with 3-0 Vicryl. Close
 the platysma with 4-0 Vicryl and close the wound with a subcuticular 5-0
 Monocryl.</p>
-<h3 class="unnumbered" id="dr-wein-thyroidectomy">Dr Wein
+<h3 class="unnumbered" id="dr-wein-thyroidectomy">Dr Wein Thyroidectomy</h3>
 <p>Similar set up to Dhingra’s. When you lift the upper subplatysmal
 flap, roll skin over a wet 4x8 gauze and suture to mandible with 2-0
 silk to retract it. Use 3 lone stars on lower flap. Split the straps.
@@ -114,8 +114,7 @@ Free the middle of the thyroid. Use middle finger on gauze to retract
 thyroid towards you. Use a ladyfinger to retract straps. Bipolar through
 fascia. When you approach superior pole, hug gland. Dr Wein doesn’t
 necessarily go hunting for the nerve</p>
-id="dr-wein-inspire-hypoglossal-nerve-implants">Dr Wein INSPIRE
-Hypoglossal Nerve Implants</h3>
+<h3 class="unnumbered" id="dr-wein-inspire-hypoglossal-nerve-implants">Dr Wein INSPIRE Hypoglossal Nerve Implants</h3>
 <p><strong>Set Up:</strong></p>
 <li><p>Patient rotated 180. Tube taped to the left</p></li>
 <li><p>Place shoulder roll. Tuck right arm. <u>Leave mouth


### PR DESCRIPTION
## Summary
- close `<h3>` tag for Dr. Dhingra’s Thyroidectomy section
- close heading tags for Dr Wein Thyroidectomy and Inspire implants sections

## Testing
- `pandoc` conversion to inspect docx (manual check)


------
https://chatgpt.com/codex/tasks/task_e_688acc77733c832f8e76994e08470963