### PR TITLE
Enhance search snippet and anchor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,3 +144,9 @@ main li {
 .floating-nav .btn:hover {
   background-color: #1565c0;
 }
+
+li span {
+  color: #555;
+  margin-left: 0.5em;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- show snippet of matching text in search results
- use text fragments so links navigate to matches even inside nested lists
- add basic snippet styling

## Testing
- `node -c search.js`

------
https://chatgpt.com/codex/tasks/task_e_688acdfc1f60832fa32bff751daf9490