### PR TITLE
Make header sticky with collapsible search bar

### DIFF
--- a/antibiogram.html
+++ b/antibiogram.html
@@ -29,6 +29,7 @@
   <p>Consult the printed antibiogram in the resident workroom or the Tufts intranet for detailed susceptibility data.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/cranial-nerves.html
+++ b/cranial-nerves.html
@@ -21,6 +21,7 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -17,8 +17,9 @@ header, footer {
 }
 
 header {
-  padding-top: 5em; /* space for fixed search bar */
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
 h1 {
@@ -86,16 +87,12 @@ main li {
 .search-form {
   display: flex;
   justify-content: center;
-  margin: 0 auto;
+  margin: 1em auto 0 auto;
   max-width: 600px;
   width: 100%;
-  position: fixed;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1000;
   background-color: #1976d2;
   padding: 0.5em;
+  transition: margin 0.3s;
 }
 
 .search-form input[type="text"] {
@@ -157,4 +154,16 @@ li span {
   color: #555;
   margin-left: 0.5em;
   font-style: italic;
+}
+
+header.collapsed {
+  padding: 0.5em 2em;
+}
+
+header.collapsed h1 {
+  display: none;
+}
+
+header.collapsed .search-form {
+  margin: 0 auto;
 }

--- a/daily-routine.html
+++ b/daily-routine.html
@@ -96,6 +96,7 @@ mso-hansi-theme-font:major-latin;mso-bidi-theme-font:major-latin;mso-bidi-font-w
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/facial-plastics.html
+++ b/facial-plastics.html
@@ -21,6 +21,7 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/facial-trauma-guide.html
+++ b/facial-trauma-guide.html
@@ -169,6 +169,7 @@ fixation.</p>
 <p>9–12 years—MMF w/ arch bars.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -1114,6 +1114,7 @@ prevertebral space</td>
 
 </li></ul>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/clinic-guide.html
+++ b/head-and-neck-surgery/clinic-guide.html
@@ -320,6 +320,7 @@ of the hottest node.</p></li></ul>
 
 </li></ul>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/follow-up-guide.html
+++ b/head-and-neck-surgery/follow-up-guide.html
@@ -34,6 +34,7 @@ most ppl – can probs avoid in T1/T2 glottic CA since It only picks up
 
 <p><a href="../index.html">Back to homepage</a></p>
 </li></ul></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/index.html
+++ b/head-and-neck-surgery/index.html
@@ -28,6 +28,7 @@
       <li><a href="staging-8th-edition.html">Staging - 8th Edition</a></li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/or-guide.html
+++ b/head-and-neck-surgery/or-guide.html
@@ -190,6 +190,7 @@ PTX</u></p>
 </li></ul>
 
 </h3></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/post-op-guide.html
+++ b/head-and-neck-surgery/post-op-guide.html
@@ -152,6 +152,7 @@ if TG(in JP) &gt; TG serum or if there are any chylomicrons</p>
 <p><a href="../index.html">Back to homepage</a></p>
 </li></ul>
 </h3></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/squamous-cell-carcinoma.html
+++ b/head-and-neck-surgery/squamous-cell-carcinoma.html
@@ -169,6 +169,7 @@ Level VI)</p></li><li><p>Supraglottic: yes for T1 N0</p></li></ul>
 
 </li></ul>
 </li></ul></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/head-and-neck-surgery/staging-8th-edition.html
+++ b/head-and-neck-surgery/staging-8th-edition.html
@@ -358,6 +358,7 @@ prevertebral space</td>
 <p><img alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " src="media/image33.png" style="width:1.88969in;height:2.90093in"/></p>
 <p><a href="../index.html">Back to homepage</a></p>
 </td></td></td></td></td></li></ol></td></td></td></ol></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
       </li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/laryngology.html
+++ b/laryngology.html
@@ -21,6 +21,7 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/levels-of-the-neck.html
+++ b/levels-of-the-neck.html
@@ -31,6 +31,7 @@
   <p>Understanding these levels is essential for staging head and neck cancers.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/local-rotational-flaps.html
+++ b/local-rotational-flaps.html
@@ -33,6 +33,7 @@
   <p>For complex reconstruction, consult a facial plastics reference for flap design and planning.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/map-of-tufts-medical-center.html
+++ b/map-of-tufts-medical-center.html
@@ -73,6 +73,7 @@
 </table>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/medications.html
+++ b/medications.html
@@ -63,6 +63,7 @@
 
 <p><a href="index.html">Back to homepage</a></p>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/monthly-routines.html
+++ b/monthly-routines.html
@@ -34,6 +34,7 @@ Oct, Jan, Apr, June. </p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/on-call-guide.html
+++ b/on-call-guide.html
@@ -257,6 +257,7 @@ patients.</p>
 </em></strong></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/on-call/calls.html
+++ b/on-call/calls.html
@@ -125,6 +125,7 @@ heart.</p></li>
 </ol></li>
 </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/on-call/consults.html
+++ b/on-call/consults.html
@@ -302,6 +302,7 @@ general, transfers go through the ED</p></li>
 from ED – What service?</h4>
 <p>In general, we have adopted the same model as Orthopedics.</p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/on-call/index.html
+++ b/on-call/index.html
@@ -26,6 +26,7 @@
       <li><a href="../facial-trauma-guide.html">Facial Trauma Guide</a></li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/or-instruments.html
+++ b/or-instruments.html
@@ -45,6 +45,7 @@
 </li></ul>
 <p><a href="index.html">Back to homepage</a></p>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/orders-discharges-and-dictations.html
+++ b/orders-discharges-and-dictations.html
@@ -100,6 +100,7 @@ ___, the attending surgeon, was present throughout the entire case.</p>
 <p><strong>Room A182 = ENT On Call Room</strong><strong> Code=0044833</strong></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/orientation/case-duty-hour-logs.html
+++ b/orientation/case-duty-hour-logs.html
@@ -41,6 +41,7 @@
       <li>All residents must update cases monthly</li>
     </ol>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/orientation/index.html
+++ b/orientation/index.html
@@ -34,6 +34,7 @@
       <li><a href="vacation-requests.html">Vacation Requests</a></li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/orientation/on-call-room.html
+++ b/orientation/on-call-room.html
@@ -22,6 +22,7 @@
     <p>Located in the Resident Suites on Farnsworth 1st floor. Ensure your badge has access.</p>
     <p><strong>Room A182</strong> code: <strong>0044833</strong></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/orientation/vacation-requests.html
+++ b/orientation/vacation-requests.html
@@ -36,6 +36,7 @@
       <li>January 1 &ndash; requests for April to June</li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otolaryngology-national-conference-schedule.html
+++ b/otolaryngology-national-conference-schedule.html
@@ -68,6 +68,7 @@ service with you (who make the schedule)</p>
 <p>January 1 – April to June</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology.html
+++ b/otology.html
@@ -588,6 +588,7 @@
 <!-- END Otology section -->
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology/clinic-guide.html
+++ b/otology/clinic-guide.html
@@ -74,6 +74,7 @@
 
   <p><a href="../index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology/index.html
+++ b/otology/index.html
@@ -26,6 +26,7 @@
       <li><a href="or-guide.html">OR Guide</a></li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology/neuro-otology-imaging.html
+++ b/otology/neuro-otology-imaging.html
@@ -398,6 +398,7 @@
 <p>Labyrinthine Concussion: BPPV like symptoms after trauma</p>
   <p><a href="../index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology/or-guide.html
+++ b/otology/or-guide.html
@@ -77,6 +77,7 @@
 <!-- END Otology section -->
   <p><a href="../index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/otology/otitis.html
+++ b/otology/otitis.html
@@ -101,6 +101,7 @@
 <p>13. If no improvement, should offer hearing aids</p>
   <p><a href="../index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/pediatric-otolaryngology.html
+++ b/pediatric-otolaryngology.html
@@ -846,6 +846,7 @@ Reconstruction (Vecchiotti &amp; Scott)
 
 
 </li></ol></li></ul></li></ul></li></ul></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/pediatric-otolaryngology/clinic-guide.html
+++ b/pediatric-otolaryngology/clinic-guide.html
@@ -287,6 +287,7 @@ skin w/ excellent blood supply for microtia)</p>
 
 
 </li></ol></li></ul></li></ul></li></ul></main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/pediatric-otolaryngology/index.html
+++ b/pediatric-otolaryngology/index.html
@@ -25,6 +25,7 @@
       <li><a href="or-guide.html">OR Guide</a></li>
     </ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/pediatric-otolaryngology/neck-masses.html
+++ b/pediatric-otolaryngology/neck-masses.html
@@ -195,6 +195,7 @@ phenylbutazone)</p></li><li><p>Sarcoidosis: Get ACE levels</p></li></ul>
 
 </li></ul>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/pediatric-otolaryngology/or-guide.html
+++ b/pediatric-otolaryngology/or-guide.html
@@ -408,6 +408,7 @@ Reconstruction (Vecchiotti &amp; Scott)
 
 
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/perioperative-aspirin-anticoagulation-guide.html
+++ b/perioperative-aspirin-anticoagulation-guide.html
@@ -200,6 +200,7 @@ etc)</p>
 
 </li></ul>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/radiology-levels-of-the-neck.html
+++ b/radiology-levels-of-the-neck.html
@@ -28,6 +28,7 @@
   <p>Example cross-sectional images can be viewed at <a href="http://headneckbrainspine.com" target="_blank" rel="noopener">headneckbrainspine.com</a>.</p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/review-of-systems.html
+++ b/review-of-systems.html
@@ -57,6 +57,7 @@
 
 <p><a href="index.html">Back to homepage</a></p>
 </main>
+  <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/rhinology.html
+++ b/rhinology.html
@@ -21,6 +21,7 @@
   <main class="container">
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/rotations.html
+++ b/rotations.html
@@ -29,6 +29,7 @@ alt="C:\Users\jharb\Downloads\SGS_sizingguide.jpg" /></p>
 style="width:5.96171in;height:3.23186in" /></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/rules-of-the-game.html
+++ b/rules-of-the-game.html
@@ -82,6 +82,7 @@ has to do their bit to leave this program better off than when you came.</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -22,6 +22,7 @@
   <main class="container">
     <ul id="results"></ul>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/site.js
+++ b/site.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const header = document.querySelector('header');
+  if (!header) return;
+  const threshold = 50;
+  const onScroll = () => {
+    if (window.scrollY > threshold) {
+      header.classList.add('collapsed');
+    } else {
+      header.classList.remove('collapsed');
+    }
+  };
+  window.addEventListener('scroll', onScroll);
+  onScroll();
+});

--- a/templates-protocols.html
+++ b/templates-protocols.html
@@ -29,6 +29,7 @@
 <p><a href="https://1drv.ms/w/s!AgoNMr1jv4esgsJIEtgeKz9gNRBggA">Resident Approval Forms for Conferences</a></p>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/tips.html
+++ b/tips.html
@@ -57,6 +57,7 @@ Add new exception &gt; Coverage &gt; New; Put start and end date</p>
 </ul>
   <p><a href="index.html">Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/weekly-routines.html
+++ b/weekly-routines.html
@@ -52,6 +52,7 @@ sends out prelim radiology rounds list</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/yearly-routines.html
+++ b/yearly-routines.html
@@ -45,6 +45,7 @@ access to the <span class="SpellE">boardvitals</span> website for questions</p>
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>
+  <script src="site.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert fixed search bar to be part of the header
- make header sticky and hide title on scroll
- add site-wide script for collapsing header

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ad1e37f54832f8a754133b29ddb42