### PR TITLE
Fix missing closing tags

### DIFF
--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -250,7 +250,7 @@ High rate of recurrence</p></li><li><p>Clark levels: <u>only useful for prognosi
 <td>T4a</td>
 <td>T4b</td>
 <td>IIC</td>
-</tr></tr></tbody>
+</tr></tbody>
 </table>
 <p>Survival: T1 95%, T2 80-95%, T3:40-85%. T4:10-30%</p>
 <ul><li><p>Treatment</p>
@@ -648,7 +648,7 @@ Check before removing any drains</p></li></ul>
 <li>Work with PT daily, OOB</li>
 <li>PT/OT consult</li>
 </ul>
-<h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy
+<h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy</h3>
 <ul><li><p>Diet: NPO</p></li><li><p>Nursing:</p>
 <ul><li><p>humidified air at all times (unless HME in place)</p></li><li><p>keep laryngectomy tube in place, clean once daily</p></li><li><p>suction laryngectomy stoma as needed for secretions</p></li><li><p>apply bacitracin ointment to chest and neck twice daily</p></li><li><p>sign above bed saying patient cannot be intubated from
 above</p></li><li><p>Leave trach collar loose fitting ( 2 fingerbreadths distance from
@@ -663,7 +663,7 @@ fistula formation (tube feeds coming out neck)</p></li></ul>
 
 
 
-<h3 class="unnumbered" id="thyroidectomy-patients">Thyroidectomy
+<h3 class="unnumbered" id="thyroidectomy-patients">Thyroidectomy</h3>
 <ul><li><p>Check PTH and iCa2+ post-op in PACU. If PTH abnormal, check iCa2+
 q4-6hours. If normal, recheck iCa2+ q8hrs.</p></li><li><p>levothyroxine: according to endocrine, <strong>levothyroxine dose
 in mcg = 1.7xpt’s weight (kg)</strong></p></li><li><p>If hypocalcemic – replete Ca2+ (see electrolyte section)</p></li></ul>
@@ -690,8 +690,7 @@ trach</p></li></ul>
 
 
 
-id="specific-complications-and-their-management"&gt;Specific Complications
-and their management</h3>
+<h3 class="unnumbered" id="specific-complications-and-their-management">Specific Complications and their management</h3>
 <h4 class="unnumbered" id="chyle-leak">Chyle Leak: </h4>
 <p>If suspected, collect from JP and send for triglycerides,
 chylomicrons. Also get serum triglycerides. Positive if TG &gt;100mg/dL

--- a/head-and-neck-surgery/post-op-guide.html
+++ b/head-and-neck-surgery/post-op-guide.html
@@ -95,7 +95,7 @@ Check before removing any drains</p></li></ul>
 <li>Work with PT daily, OOB</li>
 <li>PT/OT consult</li>
 </ul>
-<h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy
+<h3 class="unnumbered" id="laryngectomy-patients">Laryngectomy</h3>
 <ul><li><p>Diet: NPO</p></li><li><p>Nursing:</p>
 <ul><li><p>humidified air at all times (unless HME in place)</p></li><li><p>keep laryngectomy tube in place, clean once daily</p></li><li><p>suction laryngectomy stoma as needed for secretions</p></li><li><p>apply bacitracin ointment to chest and neck twice daily</p></li><li><p>sign above bed saying patient cannot be intubated from
 above</p></li><li><p>Leave trach collar loose fitting ( 2 fingerbreadths distance from
@@ -110,7 +110,7 @@ fistula formation (tube feeds coming out neck)</p></li></ul>
 
 
 
-<h3 class="unnumbered" id="thyroidectomy-patients">Thyroidectomy
+<h3 class="unnumbered" id="thyroidectomy-patients">Thyroidectomy</h3>
 <ul><li><p>Check PTH and iCa2+ post-op in PACU. If PTH abnormal, check iCa2+
 q4-6hours. If normal, recheck iCa2+ q8hrs.</p></li><li><p>levothyroxine: according to endocrine, <strong>levothyroxine dose
 in mcg = 1.7xpt’s weight (kg)</strong></p></li><li><p>If hypocalcemic – replete Ca2+ (see electrolyte section)</p></li></ul>
@@ -137,8 +137,7 @@ trach</p></li></ul>
 
 
 
-id="specific-complications-and-their-management"&gt;Specific Complications
-and their management</h3>
+<h3 class="unnumbered" id="specific-complications-and-their-management">Specific Complications and their management</h3>
 <h4 class="unnumbered" id="chyle-leak">Chyle Leak: </h4>
 <p>If suspected, collect from JP and send for triglycerides,
 chylomicrons. Also get serum triglycerides. Positive if TG &gt;100mg/dL
@@ -151,7 +150,7 @@ if TG(in JP) &gt; TG serum or if there are any chylomicrons</p>
 <p>High output &gt;500cc/day: typically need to go to OR.</p>
 <p><a href="../index.html">Back to homepage</a></p>
 </li></ul>
-</h3></main>
+</main>
   <script src="site.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- fix broken `<h3>` headings in `head-and-neck-surgery.html`
- fix broken `<h3>` headings in `post-op-guide.html`
- tidy up stray closing tags

## Testing
- `tidy -quiet -errors head-and-neck-surgery/post-op-guide.html`
- `tidy -quiet -errors head-and-neck-surgery.html | head`
- `tidy -quiet -errors rules-of-the-game.html | head`


------
https://chatgpt.com/codex/tasks/task_e_688ad3f39980832fbbf4f1c50eb124b1