### PR TITLE
Remove minor Latin tags from daily routine page

### DIFF
--- a/daily-routine.html
+++ b/daily-routine.html
@@ -22,77 +22,77 @@
   
 <h3><a name="_Toc139824162">Things to Do Before Rounds</a></h3>
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l101 level1 lfo96;
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Send Staff E-mail </span></b><span style="mso-fareast-font-family:
-Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin">(performed
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Send Staff E-mail </span></b><span style="mso-fareast-font-family:
+Calibri;mso-bidi-font-family:Calibri;">(performed
 by on-call resident)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></p>
+mso-bidi-font-family:Calibri;'><o:p></o:p></span></p>
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l101 level2 lfo96;
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">A<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Overnight Consults / Calls / Admissions / Discharges requiring
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">A<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Overnight Consults / Calls / Admissions / Discharges requiring
 follow-up</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Sign-In Pagers on Residents In-House</span></b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin"> – “In Hospital – On Page”</span><span style='mso-fareast-font-family:
-"Calibri\,Times New Roman";mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin'><o:p></o:p></span></p>
-minor-latin">3552 – Chief</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">B<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">1699– Senior(s)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">C<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">1221/5511 – Mid Level(s)</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">D<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">1777 – Junior</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">E<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">#### - Intern</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">3.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Update List &amp; Print for Everyone </span></b><b><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></b></p>
-minor-latin">On-Call (Resident, Adult Attending, &amp; Pedi Attending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></p>
-minor-latin">Room Numbers (Walk rounds order: North ascending, Floating &amp;
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Sign-In Pagers on Residents In-House</span></b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"> – “In Hospital – On Page”</span><span style='mso-fareast-font-family:
+"Calibri\,Times New Roman";mso-bidi-font-family:Calibri;
+'><o:p></o:p></span></p>
+">3552 – Chief</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">B<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">1699– Senior(s)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">C<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">1221/5511 – Mid Level(s)</span><span style='mso-fareast-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">D<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">1777 – Junior</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">E<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">#### - Intern</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">3.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Update List &amp; Print for Everyone </span></b><b><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+Calibri;'><o:p></o:p></span></b></p>
+">On-Call (Resident, Adult Attending, &amp; Pedi Attending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+Calibri;'><o:p></o:p></span></p>
+">Room Numbers (Walk rounds order: North ascending, Floating &amp;
 Main building descending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-minor-latin">Vitals / I&amp;Os (including drain outputs)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+">Vitals / I&amp;Os (including drain outputs)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 <p class="MsoNormal" style="margin-left:.4in;text-indent:0in;mso-pagination:none;
 mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin'>-The last 3 JP outputs (q8hrs) should
+Calibri;'>-The last 3 JP outputs (q8hrs) should
 be written from oldest to newest (e.g. 25→15→5)<o:p></o:p></span></p>
-minor-latin">Labs / Imaging / Cultures / Path</span><span style='mso-fareast-font-family:
+">Labs / Imaging / Cultures / Path</span><span style='mso-fareast-font-family:
 mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-bidi-font-size:7.0pt;mso-fareast-font-family:"Times New Roman";
-mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;mso-bidi-font-weight:
+mso-bidi-font-family:Calibri;;mso-bidi-font-weight:
 bold'><o:p> </o:p></span></p>
 <h3><a name="_Toc139824163"><span style='font-family:"Calibri",sans-serif;
-mso-ascii-theme-font:minor-latin;mso-hansi-theme-font:minor-latin;mso-bidi-theme-font:
-minor-latin'>Things to Do After Rounds</span></a><span style="mso-bookmark:
-_Toc139824163"></span><span style='font-family:"Calibri",sans-serif;mso-ascii-theme-font:
-minor-latin;mso-fareast-font-family:"Times New Roman";mso-hansi-theme-font:
-minor-latin;mso-bidi-theme-font:minor-latin'><o:p></o:p></span></h3>
+;;
+'>Things to Do After Rounds</span></a><span style="mso-bookmark:
+_Toc139824163"></span><span style='font-family:"Calibri",sans-serif;
+;mso-fareast-font-family:"Times New Roman";
+;'><o:p></o:p></span></h3>
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l138 level1 lfo97;
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Update List</span></b><b><span style='mso-fareast-font-family:
-minor-latin'><o:p></o:p></span></b></p>
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">1.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Update List</span></b><b><span style='mso-fareast-font-family:
+'><o:p></o:p></span></b></p>
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l138 level2 lfo97;
-minor-latin">Room Numbers (Walk rounds order: North ascending, Main building
+">Room Numbers (Walk rounds order: North ascending, Main building
 descending)</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-minor-latin">Daily Hospital Course</span><span style='mso-fareast-font-family:
-minor-latin">Meds / Diet / Lines / Drains</span><span style='mso-fareast-font-family:
-minor-latin">Labs / Imaging / Cultures</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">F<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">To Do List</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">G<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Discharge Paperwork / Scripts</span><span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;mso-bidi-theme-font:
-minor-latin">Update Pathology / Trauma </span></b><b><span style='mso-fareast-font-family:
-minor-latin">Sign-out Pagers</span></b><b><span style='mso-fareast-font-family:
-minor-latin">1777 = “Out of Hospital – On Page”</span><span style='mso-fareast-font-family:
-minor-latin">1777 = Covered by on call resident</span><span style='mso-fareast-font-family:
-minor-latin">On-call resident = “Out of Hospital – On Page”</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-minor-latin">4100 (Chief) = “Redirect to Chief’s cell phone</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin'>”<o:p></o:p></span></p>
-minor-latin">All other pagers = “Out of hospital – Not Available”</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+">Daily Hospital Course</span><span style='mso-fareast-font-family:
+">Meds / Diet / Lines / Drains</span><span style='mso-fareast-font-family:
+">Labs / Imaging / Cultures</span><span style='mso-fareast-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">F<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">To Do List</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">G<span style='font:7.0pt "Times New Roman"'>  </span></span></span><!--[endif]--><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Discharge Paperwork / Scripts</span><span style='mso-fareast-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"><!--[if !supportLists]--><b><span style="mso-bidi-font-family:Calibri;"><span style="mso-list:Ignore">2.<span style='font:7.0pt "Times New Roman"'> </span></span></span></b><!--[endif]--><b><span style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+">Update Pathology / Trauma </span></b><b><span style='mso-fareast-font-family:
+">Sign-out Pagers</span></b><b><span style='mso-fareast-font-family:
+">1777 = “Out of Hospital – On Page”</span><span style='mso-fareast-font-family:
+">1777 = Covered by on call resident</span><span style='mso-fareast-font-family:
+">On-call resident = “Out of Hospital – On Page”</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+">4100 (Chief) = “Redirect to Chief’s cell phone</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
+Calibri;'>”<o:p></o:p></span></p>
+">All other pagers = “Out of hospital – Not Available”</span><span style='mso-fareast-font-family:"Calibri\,Times New Roman";mso-bidi-font-family:
 mso-layout-grid-align:none;punctuation-wrap:simple;"><span style='mso-bidi-font-size:7.0pt;font-family:"Calibri Light",sans-serif;
-mso-ascii-theme-font:major-latin;mso-fareast-font-family:"Times New Roman";
-mso-hansi-theme-font:major-latin;mso-bidi-theme-font:major-latin;mso-bidi-font-weight:
+;mso-fareast-font-family:"Times New Roman";
+;;mso-bidi-font-weight:
 
   <p><a href='index.html'>Back to homepage</a></p>
   </main>


### PR DESCRIPTION
## Summary
- cleanup `daily-routine.html` by stripping `minor-latin` and `major-latin` style attributes

## Testing
- `npx --yes htmlhint daily-routine.html` *(fails: found 90 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688adbf07174832f93926893f3a201bd