### PR TITLE
Review HTML for missing tags

### DIFF
--- a/head-and-neck-surgery.html
+++ b/head-and-neck-surgery.html
@@ -240,6 +240,7 @@ High rate of recurrence</p></li><li><p>Clark levels: <u>only useful for prognosi
 <td>T1a</td>
 <td>IA</td>
 <td>III</td>
+</tr>
 <tr class="even">
 <td>T1b</td>
 <td>IB</td>
@@ -252,7 +253,8 @@ High rate of recurrence</p></li><li><p>Clark levels: <u>only useful for prognosi
 <td>T4a</td>
 <td>T4b</td>
 <td>IIC</td>
-</tr></tbody>
+</tr>
+</tbody>
 </table>
 <p>Survival: T1 95%, T2 80-95%, T3:40-85%. T4:10-30%</p>
 <ul><li><p>Treatment</p>
@@ -289,7 +291,6 @@ Neck Squamous Cell Carcinoma</h2>
 <p>Stage 2 — 75-85%</p>
 <p>Stage 3 — 50%</p>
 <p>Stage 4 — 25-35%</p>
-<h4 class="unnumbered" id="section-20"></h4>
 <h4 class="unnumbered" id="who-gets-chemotherapy">Who gets
 chemotherapy</h4>
 <ul><li><p>Nasopharyngeal CA: Stage III-IV, some Stage II</p></li><li><p>Unresectable H&amp;N Ca</p></li><li><p>Laryngeal CA: induction cisplatin/5-FU for organ
@@ -299,12 +300,10 @@ ECS</strong></p></li></ul>
 
 
 
-<h4 class="unnumbered" id="section-21"></h4>
 <h4 class="unnumbered" id="who-gets-radiation-therapy-to-neck">Who gets
 radiation therapy to neck</h4>
 <ul><li><p>Patients with N1 disease + extracapsular spread</p></li><li><p>Patients with N2-3 disease</p></li></ul>
 
-<h4 class="unnumbered" id="section-22"></h4>
 <h4 class="unnumbered" id="who-gets-a-neck-dissection">Who gets a neck
 dissection: </h4>
 <p>Classic training is that if risk of spread to lymph nodes is
@@ -314,7 +313,6 @@ dissection: </h4>
 
 
 
-<h3 class="unnumbered" id="section-23"></h3>
 <h3 class="unnumbered" id="oral-cavity-ca">Oral Cavity CA</h3>
 <p><strong>Management</strong></p>
 <ul><li><p>Excision w/ reconstruction. Tumors &lt;2cm can be approached
@@ -397,7 +395,6 @@ laryngeal pharyngeal wall if needed</p></li><li><p>Radiation: Used for T1/T2 les
 <ul><li><p>Hypopharyngeal: Yes starting at T1 (With T2 or N1, should also do
 Level VI)</p></li><li><p>Supraglottic: yes for T1 N0</p></li></ul>
 
-<h2 class="unnumbered" id="section-24"></h2>
 <h2 class="unnumbered" id="post--hn-cancer-treatment-follow-up-guide">Post- H&amp;N Cancer
 Treatment Follow-up Guide:</h2>
 <ul><li><p>Interval H&amp;P w/ fiberoptic or mirror exam:</p>

--- a/head-and-neck-surgery/clinic-guide.html
+++ b/head-and-neck-surgery/clinic-guide.html
@@ -240,6 +240,7 @@ High rate of recurrence</p></li><li><p>Clark levels: <u>only useful for prognosi
 <td>T1a</td>
 <td>IA</td>
 <td>III</td>
+</tr>
 <tr class="even">
 <td>T1b</td>
 <td>IB</td>
@@ -252,7 +253,8 @@ High rate of recurrence</p></li><li><p>Clark levels: <u>only useful for prognosi
 <td>T4a</td>
 <td>T4b</td>
 <td>IIC</td>
-</tr></tbody>
+</tr>
+</tbody>
 </table>
 <p>Survival: T1 95%, T2 80-95%, T3:40-85%. T4:10-30%</p>
 <ul><li><p>Treatment</p>

--- a/head-and-neck-surgery/squamous-cell-carcinoma.html
+++ b/head-and-neck-surgery/squamous-cell-carcinoma.html
@@ -28,7 +28,6 @@ Neck Squamous Cell Carcinoma</h2>
 <p>Stage 2 — 75-85%</p>
 <p>Stage 3 — 50%</p>
 <p>Stage 4 — 25-35%</p>
-<h4 class="unnumbered" id="section-20"></h4>
 <h4 class="unnumbered" id="who-gets-chemotherapy">Who gets
 chemotherapy</h4>
 <ul><li><p>Nasopharyngeal CA: Stage III-IV, some Stage II</p></li><li><p>Unresectable H&amp;N Ca</p></li><li><p>Laryngeal CA: induction cisplatin/5-FU for organ
@@ -38,12 +37,10 @@ ECS</strong></p></li></ul>
 
 
 
-<h4 class="unnumbered" id="section-21"></h4>
 <h4 class="unnumbered" id="who-gets-radiation-therapy-to-neck">Who gets
 radiation therapy to neck</h4>
 <ul><li><p>Patients with N1 disease + extracapsular spread</p></li><li><p>Patients with N2-3 disease</p></li></ul>
 
-<h4 class="unnumbered" id="section-22"></h4>
 <h4 class="unnumbered" id="who-gets-a-neck-dissection">Who gets a neck
 dissection: </h4>
 <p>Classic training is that if risk of spread to lymph nodes is
@@ -53,7 +50,6 @@ dissection: </h4>
 
 
 
-<h3 class="unnumbered" id="section-23"></h3>
 <h3 class="unnumbered" id="oral-cavity-ca">Oral Cavity CA</h3>
 <p><strong>Management</strong></p>
 <ul><li><p>Excision w/ reconstruction. Tumors &lt;2cm can be approached

--- a/on-call/calls.html
+++ b/on-call/calls.html
@@ -37,7 +37,6 @@ patient has down syndrome)</p></li>
 parents can’t get kids to drink the meds). Offer PR Tylenol to help
 catch up pain</p></li>
 </ul>
-<h4 class="unnumbered" id="section-4"></h4>
 <h4 class="unnumbered" id="post-septorhinoplasty-qa">Post
 Septorhinoplasty Q&amp;A</h4>
 <ul>

--- a/pediatric-otolaryngology.html
+++ b/pediatric-otolaryngology.html
@@ -31,7 +31,6 @@ The patient presents to clinic today with __</p>
 <p>_____ is a __-year-old patient who is followed by this clinic for __.
 He/She was last seen on ___, at that time ___ was noted and the plan for
 the patient was ___. Today, the patient returns. Since then ___</p>
-<h4 class="unnumbered" id="section-16"></h4>
 <h4 class="unnumbered" id="need-to-ask">NEED to ASK</h4>
 <ul>
 <li>Weight</li>
@@ -235,7 +234,6 @@ Atresia</h3>
 <p>Workup: If newborn hearing screen on contralateral ear is ok, can
 <u>delay formal audiogram until 6-7 months of age</u> (ABR if fails on
 that side)</p>
-<h4 class="unnumbered" id="section-17"></h4>
 <h4 class="unnumbered" id="microtia">Microtia</h4>
 <p><strong>Grade I</strong>: cup or lop ear. <strong>Grade II</strong>:
 rudimentary subunits <strong>Grade III</strong>: peanut ear
@@ -251,7 +249,6 @@ atresia, retardation, genital hypoplasia, ear abnormalities)</p>
 birth, wait 1 week to see if ear self corrects (1/3 of cases) then can
 do molding, but this must be done within first 3 weeks (mold for 4
 weeks). After 6 weeks, cannot mold</p>
-<h4 class="unnumbered" id="section-18"></h4>
 <h4 class="unnumbered" id="aural-atresia">Aural Atresia</h4>
 <p>Associated w/ microtia in 55-90%.</p>
 <p><strong>Jahrsdoerfer</strong> (10 total points, &gt;7 = candidate for
@@ -290,7 +287,6 @@ Brucella (cows/pigs), ACE levels (Sarcoid)</p>
 </blockquote>
 <p><strong>Acquired + suspicious for malignancy (eg HL)</strong>:
 consider CBC, CXR, CT and excise</p>
-<h3 class="unnumbered" id="section-19"></h3>
 <h3 class="unnumbered" id="congenital-neck-masses">CONGENITAL NECK
 MASSES</h3>
 <p><strong>Thyroglossal Duct cysts</strong>:</p>

--- a/pediatric-otolaryngology/clinic-guide.html
+++ b/pediatric-otolaryngology/clinic-guide.html
@@ -31,7 +31,6 @@ The patient presents to clinic today with __</p>
 <p>_____ is a __-year-old patient who is followed by this clinic for __.
 He/She was last seen on ___, at that time ___ was noted and the plan for
 the patient was ___. Today, the patient returns. Since then ___</p>
-<h4 class="unnumbered" id="section-16"></h4>
 <h4 class="unnumbered" id="need-to-ask">NEED to ASK</h4>
 <ul>
 <li>Weight</li>
@@ -234,8 +233,6 @@ Goldenhar -&gt; Nager Syndrome</p></li></ul>
 Atresia</h3>
 <p>Workup: If newborn hearing screen on contralateral ear is ok, can
 <u>delay formal audiogram until 6-7 months of age</u> (ABR if fails on
-that side)</p>
-<h4 class="unnumbered" id="section-17"></h4>
 <h4 class="unnumbered" id="microtia">Microtia</h4>
 <p><strong>Grade I</strong>: cup or lop ear. <strong>Grade II</strong>:
 rudimentary subunits <strong>Grade III</strong>: peanut ear
@@ -249,9 +246,7 @@ noted) <strong>CHARGE</strong> (coloboma, heart defects, choanal
 atresia, retardation, genital hypoplasia, ear abnormalities)</p>
 <p>For crypotia, stahl ear or other partial deformations, noted at
 birth, wait 1 week to see if ear self corrects (1/3 of cases) then can
-do molding, but this must be done within first 3 weeks (mold for 4
 weeks). After 6 weeks, cannot mold</p>
-<h4 class="unnumbered" id="section-18"></h4>
 <h4 class="unnumbered" id="aural-atresia">Aural Atresia</h4>
 <p>Associated w/ microtia in 55-90%.</p>
 <p><strong>Jahrsdoerfer</strong> (10 total points, &gt;7 = candidate for

--- a/pediatric-otolaryngology/neck-masses.html
+++ b/pediatric-otolaryngology/neck-masses.html
@@ -43,7 +43,6 @@ Brucella (cows/pigs), ACE levels (Sarcoid)</p>
 </blockquote>
 <p><strong>Acquired + suspicious for malignancy (eg HL)</strong>:
 consider CBC, CXR, CT and excise</p>
-<h3 class="unnumbered" id="section-19"></h3>
 <h3 class="unnumbered" id="congenital-neck-masses">CONGENITAL NECK
 MASSES</h3>
 <p><strong>Thyroglossal Duct cysts</strong>:</p>


### PR DESCRIPTION
## Summary
- fix an invalid table in head and neck surgery pages
- remove empty heading placeholders from several pages

## Testing
- `html5validator head-and-neck-surgery.html head-and-neck-surgery/clinic-guide.html head-and-neck-surgery/squamous-cell-carcinoma.html on-call/calls.html pediatric-otolaryngology.html pediatric-otolaryngology/neck-masses.html pediatric-otolaryngology/clinic-guide.html`

------
https://chatgpt.com/codex/tasks/task_e_688b45834270832f9653956e6db0e572