### PR TITLE
Fix HTML ampersands in head-and-neck pages

### DIFF
--- a/head-and-neck-surgery/follow-up-guide.html
+++ b/head-and-neck-surgery/follow-up-guide.html
@@ -3,13 +3,13 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Post-HPLACEHOLDERamp;N Cancer Follow-up Guide</title>
+<title>Post-H&amp;N Cancer Follow-up Guide</title>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet"/>
 <link href="../css/style.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
-<h1>Post-HPLACEHOLDERamp;N Cancer Follow-up Guide</h1>
+<h1>Post-H&amp;N Cancer Follow-up Guide</h1>
 <form action="../search.html" class="search-form" method="get">
 <input name="q" placeholder="Search" required="" type="text"/>
 <button class="btn waves-effect waves-light" type="submit">Search</button>

--- a/head-and-neck-surgery/or-guide.html
+++ b/head-and-neck-surgery/or-guide.html
@@ -3,13 +3,13 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Head PLACEHOLDERamp; Neck OR Guide</title>
+<title>Head &amp; Neck OR Guide</title>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet"/>
 <link href="../css/style.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
-<h1>Head PLACEHOLDERamp; Neck OR Guide</h1>
+<h1>Head &amp; Neck OR Guide</h1>
 <form action="../search.html" class="search-form" method="get">
 <input name="q" placeholder="Search" required="" type="text"/>
 <button class="btn waves-effect waves-light" type="submit">Search</button>

--- a/head-and-neck-surgery/post-op-guide.html
+++ b/head-and-neck-surgery/post-op-guide.html
@@ -3,13 +3,13 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Head PLACEHOLDERamp; Neck Post-op Guide</title>
+<title>Head &amp; Neck Post-op Guide</title>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet"/>
 <link href="../css/style.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
-<h1>Head PLACEHOLDERamp; Neck Post-op Guide</h1>
+<h1>Head &amp; Neck Post-op Guide</h1>
 <form action="../search.html" class="search-form" method="get">
 <input name="q" placeholder="Search" required="" type="text"/>
 <button class="btn waves-effect waves-light" type="submit">Search</button>

--- a/head-and-neck-surgery/squamous-cell-carcinoma.html
+++ b/head-and-neck-surgery/squamous-cell-carcinoma.html
@@ -3,13 +3,13 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Head PLACEHOLDERamp; Neck Squamous Cell Carcinoma</title>
+<title>Head &amp; Neck Squamous Cell Carcinoma</title>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet"/>
 <link href="../css/style.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
-<h1>Head PLACEHOLDERamp; Neck Squamous Cell Carcinoma</h1>
+<h1>Head &amp; Neck Squamous Cell Carcinoma</h1>
 <form action="../search.html" class="search-form" method="get">
 <input name="q" placeholder="Search" required="" type="text"/>
 <button class="btn waves-effect waves-light" type="submit">Search</button>

--- a/head-and-neck-surgery/staging-8th-edition.html
+++ b/head-and-neck-surgery/staging-8th-edition.html
@@ -3,13 +3,13 @@
 <html>
 <head>
 <meta charset="utf-8"/>
-<title>Head PLACEHOLDERamp; Neck Staging - 8th Edition</title>
+<title>Head &amp; Neck Staging - 8th Edition</title>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet"/>
 <link href="../css/style.css" rel="stylesheet"/>
 </head>
 <body>
 <header>
-<h1>Head PLACEHOLDERamp; Neck Staging - 8th Edition</h1>
+<h1>Head &amp; Neck Staging - 8th Edition</h1>
 <form action="../search.html" class="search-form" method="get">
 <input name="q" placeholder="Search" required="" type="text"/>
 <button class="btn waves-effect waves-light" type="submit">Search</button>


### PR DESCRIPTION
## Summary
- replace placeholder `amp;` strings in titles and headers with encoded ampersands

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b4c848cc0832f8a3e133defe5e17a