### PR TITLE
Refactor initial markdown pages to pure Markdown

### DIFF
--- a/antibiogram.md
+++ b/antibiogram.md
@@ -2,12 +2,14 @@
 layout: default
 title: Antibiogram
 ---
-<p>The Tufts antibiogram guides empiric therapy for common ENT infections. The table below lists frequently used regimens. Always confirm current sensitivities with the hospital antibiogram.</p>
-  <ul>
-    <li><strong>Acute otitis media</strong> – high dose amoxicillin or amoxicillin‑clavulanate.</li>
-    <li><strong>Acute sinusitis</strong> – amoxicillin‑clavulanate is first line; doxycycline if penicillin allergic.</li>
-    <li><strong>Peritonsillar abscess</strong> – ampicillin‑sulbactam or clindamycin to cover streptococci and anaerobes.</li>
-    <li><strong>Post‑operative wound infection</strong> – tailor to culture results; cefazolin or clindamycin are common empiric choices.</li>
-  </ul>
-  <p>Consult the printed antibiogram in the resident workroom or the Tufts intranet for detailed susceptibility data.</p>
-  <p><a href="index.html">Back to homepage</a></p>
+
+The Tufts antibiogram guides empiric therapy for common ENT infections. The table below lists frequently used regimens. Always confirm current sensitivities with the hospital antibiogram.
+
+- **Acute otitis media** – high dose amoxicillin or amoxicillin‑clavulanate.
+- **Acute sinusitis** – amoxicillin‑clavulanate is first line; doxycycline if penicillin allergic.
+- **Peritonsillar abscess** – ampicillin‑sulbactam or clindamycin to cover streptococci and anaerobes.
+- **Post‑operative wound infection** – tailor to culture results; cefazolin or clindamycin are common empiric choices.
+
+Consult the printed antibiogram in the resident workroom or the Tufts intranet for detailed susceptibility data.
+
+[Back to homepage](index.html)

--- a/convert_to_pure_markdown.py
+++ b/convert_to_pure_markdown.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def convert_md(file_path: Path):
+    text = file_path.read_text(encoding='utf-8')
+    front_matter = ''
+    body = text
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            front_matter = '---' + parts[1] + '---\n'
+            body = parts[2].lstrip('\n')
+    try:
+        result = subprocess.run(
+            ["pandoc", "-f", "markdown", "-t", "markdown", "--markdown-headings=atx", "--wrap=preserve"],
+            input=body,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Pandoc failed on {file_path}: {e}")
+        return
+    output = front_matter + result.stdout
+    file_path.write_text(output, encoding='utf-8')
+    print(f"Converted {file_path}")
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent
+    paths = subprocess.check_output(['git', 'ls-files', '*.md'], text=True)
+    for rel_path in paths.strip().split('\n'):
+        path = repo_root / rel_path
+        convert_md(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/cranial-nerves.md
+++ b/cranial-nerves.md
@@ -2,4 +2,5 @@
 layout: default
 title: Cranial Nerves
 ---
-<p><a href="index.html">Back to homepage</a></p>
+
+[Back to homepage](index.html)

--- a/facial-plastics.md
+++ b/facial-plastics.md
@@ -2,4 +2,5 @@
 layout: default
 title: Facial Plastics
 ---
-<p><a href="index.html">Back to homepage</a></p>
+
+[Back to homepage](index.html)


### PR DESCRIPTION
## Summary
- convert `antibiogram.md`, `cranial-nerves.md`, and `facial-plastics.md` to use Markdown syntax only

## Testing
- `pandoc --version | head -n 1`

------
https://chatgpt.com/codex/tasks/task_e_688bd6fae39c832fab7dbd51cb169ab9