### PR TITLE
Clean up leftover HTML markers

### DIFF
--- a/daily-routine.md
+++ b/daily-routine.md
@@ -3,13 +3,13 @@ layout: default
 title: Daily Routine
 ---
 <h3>
-`<a name="_Toc139824162">`{=html}Things to Do Before Rounds`</a>`{=html}
+`<a name="_Toc139824162">Things to Do Before Rounds`</a>
 </h3>
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l101 level1 lfo96;
 mso-layout-grid-align:none;punctuation-wrap:simple;">
 <!--[if !supportLists]-->
-[[1.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}`<b>`{=html}[Send Staff E-mail ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
-"}`</b>`{=html}[(performed
+[[1.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`<b>[Send Staff E-mail ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"}`</b>[(performed
 by on-call resident)]{style="mso-fareast-font-family:
 Calibri;mso-bidi-font-family:Calibri;"}[]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";
 mso-bidi-font-family:Calibri;"}
@@ -17,49 +17,49 @@ mso-bidi-font-family:Calibri;"}
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l101 level2 lfo96;
 mso-layout-grid-align:none;punctuation-wrap:simple;">
 <!--[if !supportLists]-->
-[[A[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[Overnight Consults / Calls / Admissions / Discharges requiring
+[[A[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[Overnight Consults / Calls / Admissions / Discharges requiring
 follow-up]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[2.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}`<b>`{=html}[Sign-In Pagers on Residents In-House]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
-"}`</b>`{=html}[ -- "In Hospital -- On Page"]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[2.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`<b>[Sign-In Pagers on Residents In-House]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"}`</b>[ -- "In Hospital -- On Page"]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}[]{style="mso-fareast-font-family:
 \"Calibri\\,Times New Roman\";mso-bidi-font-family:Calibri;
 "}
 </p>
-"\>3552 -- Chief`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[1699-- Senior(s)]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"\>3552 -- Chief`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[1699-- Senior(s)]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[C[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[1221/5511 -- Mid Level(s)]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[C[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[1221/5511 -- Mid Level(s)]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[D[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[1777 -- Junior]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[D[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[1777 -- Junior]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[E[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[\#### - Intern]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[E[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[\#### - Intern]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}`<b>`{=html}[[3.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`{=html}`<!--[endif]-->`{=html}`<b>`{=html}[Update List & Print for Everyone ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
-"}`</b>`{=html}`<b>`{=html}[]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
-Calibri;"}`</b>`{=html}
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`<b>[[3.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`<!--[endif]-->`<b>[Update List & Print for Everyone ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"}`</b>`<b>[]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
+Calibri;"}`</b>
 </p>
-"\>On-Call (Resident, Adult Attending, & Pedi Attending)`</span>`{=html}[]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
+"\>On-Call (Resident, Adult Attending, & Pedi Attending)`</span>[]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
 Calibri;"}
 </p>
 "\>Room Numbers (Walk rounds order: North ascending, Floating &
-Main building descending)`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-"\>Vitals / I&Os (including drain outputs)`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
+Main building descending)`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
+"\>Vitals / I&Os (including drain outputs)`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
 <p class="MsoNormal" style="margin-left:.4in;text-indent:0in;mso-pagination:none;
 mso-layout-grid-align:none;punctuation-wrap:simple;">
 [-The last 3 JP outputs (q8hrs) should
 be written from oldest to newest (e.g. 25→15→5)]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
 Calibri;"}
 </p>
-"\>Labs / Imaging / Cultures / Path`</span>`{=html}\<span style='mso-fareast-font-family:
+"\>Labs / Imaging / Cultures / Path`</span>\<span style='mso-fareast-font-family:
 mso-layout-grid-align:none;punctuation-wrap:simple;"\>[]{style="mso-bidi-font-size:7.0pt;mso-fareast-font-family:\"Times New Roman\";
 mso-bidi-font-family:Calibri;;mso-bidi-font-weight:
 bold"}
 </p>
 <h3>
-`<a name="_Toc139824163">`{=html}[Things to Do After Rounds]{style="font-family:\"Calibri\",sans-serif;
+`<a name="_Toc139824163">[Things to Do After Rounds]{style="font-family:\"Calibri\",sans-serif;
 ;;
-"}`</a>`{=html}[]{style="mso-bookmark:
+"}`</a>[]{style="mso-bookmark:
 _Toc139824163"}[]{style="font-family:\"Calibri\",sans-serif;
 ;mso-fareast-font-family:\"Times New Roman\";
 ;"}
@@ -67,33 +67,33 @@ _Toc139824163"}[]{style="font-family:\"Calibri\",sans-serif;
 <p class="MsoNormal" style="mso-pagination:none;mso-list:l138 level1 lfo97;
 mso-layout-grid-align:none;punctuation-wrap:simple;">
 <!--[if !supportLists]-->
-`<b>`{=html}[[1.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`{=html}`<!--[endif]-->`{=html}`<b>`{=html}[Update List]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
-"}`</b>`{=html}`<b>`{=html}[]{style="mso-fareast-font-family:
-"}`</b>`{=html}
+`<b>[[1.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`<!--[endif]-->`<b>[Update List]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"}`</b>`<b>[]{style="mso-fareast-font-family:
+"}`</b>
 </p>
 <p class="MsoNormal" style="margin-left:.4in;mso-pagination:none;mso-list:l138 level2 lfo97;
 ">
 Room Numbers (Walk rounds order: North ascending, Main building
-descending)`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-"\>Daily Hospital Course`</span>`{=html}\<span style='mso-fareast-font-family:"\>Meds / Diet / Lines / Drains`</span>`{=html}\<span style='mso-fareast-font-family:
-"\>Labs / Imaging / Cultures`</span>`{=html}\<span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[F[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[To Do List]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+descending)`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
+"\>Daily Hospital Course`</span>\<span style='mso-fareast-font-family:"\>Meds / Diet / Lines / Drains`</span>\<span style='mso-fareast-font-family:
+"\>Labs / Imaging / Cultures`</span>\<span style='mso-fareast-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[F[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[To Do List]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}[[G[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->`{=html}[Discharge Paperwork / Scripts]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->[[G[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`<!--[endif]-->[Discharge Paperwork / Scripts]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
 "}\<span style='mso-fareast-font-family:
-mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`{=html}`<b>`{=html}[[2.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`{=html}`<!--[endif]-->`{=html}`<b>`{=html}[Update Pathology / Trauma ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
-"}`</b>`{=html}`<b>`{=html}\<span style='mso-fareast-font-family:
-"\>Sign-out Pagers`</span>`{=html}`</b>`{=html}`<b>`{=html}\<span style='mso-fareast-font-family:"\>1777 = "Out of Hospital -- On Page"`</span>`{=html}\<span style='mso-fareast-font-family:
-"\>1777 = Covered by on call resident`</span>`{=html}\<span style='mso-fareast-font-family:"\>On-call resident = "Out of Hospital -- On Page"`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
-"\>4100 (Chief) = "Redirect to Chief's cell phone`</span>`{=html}["]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
+mso-layout-grid-align:none;punctuation-wrap:simple;"\>`<!--[if !supportLists]-->`<b>[[2.[ ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:Calibri;"}`</b>`<!--[endif]-->`<b>[Update Pathology / Trauma ]{style="mso-fareast-font-family:Calibri;mso-bidi-font-family:Calibri;
+"}`</b>`<b>\<span style='mso-fareast-font-family:
+"\>Sign-out Pagers`</span>`</b>`<b>\<span style='mso-fareast-font-family:"\>1777 = "Out of Hospital -- On Page"`</span>\<span style='mso-fareast-font-family:
+"\>1777 = Covered by on call resident`</span>\<span style='mso-fareast-font-family:"\>On-call resident = "Out of Hospital -- On Page"`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
+"\>4100 (Chief) = "Redirect to Chief's cell phone`</span>["]{style="mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:
 Calibri;"}
 </p>
 
-"\>All other pagers = "Out of hospital -- Not Available"`</span>`{=html}\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
+"\>All other pagers = "Out of hospital -- Not Available"`</span>\<span style='mso-fareast-font-family:"Calibri,Times New Roman";mso-bidi-font-family:
 mso-layout-grid-align:none;punctuation-wrap:simple;"\>\<span style='mso-bidi-font-size:7.0pt;font-family:"Calibri Light",sans-serif;
 ;mso-fareast-font-family:"Times New Roman";
 ;;mso-bidi-font-weight:
 
 <p>
-`<a href='index.html'>`{=html}Back to homepage`</a>`{=html}
+`<a href='index.html'>Back to homepage`</a>
 </p>

--- a/facial-trauma-guide.md
+++ b/facial-trauma-guide.md
@@ -53,10 +53,10 @@ Follow up
 <thead>
 <tr class="header">
 <th>
-`<strong>`{=html}Timing of Trauma`</strong>`{=html}
+`<strong>Timing of Trauma`</strong>
 </th>
 <th>
-`<strong>`{=html}Follow up`</strong>`{=html}
+`<strong>Follow up`</strong>
 </th>
 </tr>
 </thead>
@@ -113,7 +113,7 @@ Maxillary sinus fractures
 Zygomatic arch fracture
 </li>
 <li>
-Orbital floor fracture (has been evaluated by Ophtho and IOP/fundoscopic exam/visual acuity normal and no subjective vision complaints `<strong>`{=html}ie no entrapment)`</strong>`{=html}
+Orbital floor fracture (has been evaluated by Ophtho and IOP/fundoscopic exam/visual acuity normal and no subjective vision complaints `<strong>ie no entrapment)`</strong>
 </li>
 <li>
 Mandible fracture (non displaced and no intraoral lacerations)
@@ -275,7 +275,7 @@ In general just do MMF as ORIF on mandible may affect dentition. Open
 at 7-10days for physiotherapy
 </p>
 <p>
-`<strong>`{=html}Younger than 2 years`</strong>`{=html}---Before age 2, a child's jaws
+`<strong>Younger than 2 years`</strong>---Before age 2, a child's jaws
 are often edentulous. splint with
 </p>
 <p>
@@ -295,5 +295,5 @@ fixation.
 9--12 years---MMF w/ arch bars.
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/head-and-neck-surgery.md
+++ b/head-and-neck-surgery.md
@@ -83,7 +83,7 @@ Similar to Dr. O'Leary's clinic flow
 Burning Mouth Consults
 </h3>
 <p>
-`<em>`{=html}Dr. O'Leary's workup`</em>`{=html}
+`<em>Dr. O'Leary's workup`</em>
 </p>
 <ul>
 <li>
@@ -180,20 +180,20 @@ Initial workup of palpable or incidentally found nodules 
 <ul>
 <li>
 <p>
-`<strong>`{=html}TSH `</strong>`{=html}\[Free T`<sub>`{=html}4`</sub>`{=html}\]
-and `<strong>`{=html}Ultrasound `</strong>`{=html} 
+`<strong>TSH `</strong>\[Free T`<sub>4`</sub>\]
+and `<strong>Ultrasound `</strong> 
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Normal or high TSH`</strong>`{=html} → no need for reuptake
+`<strong>Normal or high TSH`</strong> → no need for reuptake
 radionuclide cscan 
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Low`</strong>`{=html} TSH → get a Iodine`<sup>`{=html}123`</sup>`{=html} or
-Technetium`<sup>`{=html}99`</sup>`{=html} reuptake scan 
+`<strong>Low`</strong> TSH → get a Iodine`<sup>123`</sup> or
+Technetium`<sup>99`</sup> reuptake scan 
 </p>
 <ol type="1">
 <li>
@@ -214,7 +214,7 @@ Multiple nodules? Evaluate each one separately. 
 <ul>
 <li>
 <p>
-If TSH low or normal. Get I`<sup>`{=html}123`</sup>`{=html} scan to see if there
+If TSH low or normal. Get I`<sup>123`</sup> scan to see if there
 are autonomous nodules  
 </p>
 </li>
@@ -235,7 +235,7 @@ Don't bother if its completely cystic 
 </li>
 <li>
 <p>
-Perform FNA if nodule is (A) \>2cm `<strong>`{=html} or `</strong>`{=html}(B) 
+Perform FNA if nodule is (A) \>2cm `<strong> or `</strong>(B) 
 \>1cm + suspicious features 
 </p>
 </li>
@@ -246,7 +246,7 @@ Suspicious Ultrasound features (70% chance of malignancy) 
 <ul>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Hypo`</u>`{=html}`</strong>`{=html}echoic - think hypOH DEAR ITS
+`<strong>`<u>Hypo`</u>`</strong>echoic - think hypOH DEAR ITS
 CANCER 
 </p>
 <ul>
@@ -447,8 +447,8 @@ exist
 <li>
 <p>
 Suspicious if: present for \>2 weeks w/o change in size
-`<u>`{=html}or`</u>`{=html} if on exam mass is (1) fixed to adjacent structure (2) firm
-(3) \>1.5cm or (4) has ulceration of overlying skin `<u>`{=html}or`</u>`{=html} history
+`<u>or`</u> if on exam mass is (1) fixed to adjacent structure (2) firm
+(3) \>1.5cm or (4) has ulceration of overlying skin `<u>or`</u> history
 highly suspicious
 </p>
 <ul>
@@ -480,7 +480,7 @@ If testing is negative:
 <ul>
 <li>
 <p>
-Can either with open biopsy (should `<u>`{=html}always`</u>`{=html} be done with a
+Can either with open biopsy (should `<u>always`</u> be done with a
 direct laryngoscopy)
 </p>
 </li>
@@ -658,32 +658,32 @@ High rate of recurrence
 </li>
 <li>
 <p>
-Clark levels: `<u>`{=html}only useful for prognosis in T1 lesions.`</u>`{=html}
+Clark levels: `<u>only useful for prognosis in T1 lesions.`</u>
 </p>
 <ul>
 <li>
 <p>
-`<strong>`{=html}epidermis`</strong>`{=html} only = stage I.
+`<strong>epidermis`</strong> only = stage I.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Into papillary`</strong>`{=html} dermis = II.
+`<strong>Into papillary`</strong> dermis = II.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}All of papillary`</strong>`{=html} dermis =III.
+`<strong>All of papillary`</strong> dermis =III.
 </p>
 </li>
 <li>
 <p>
-Invades `<strong>`{=html}reticular`</strong>`{=html} dermis = IV.
+Invades `<strong>reticular`</strong> dermis = IV.
 </p>
 </li>
 <li>
 <p>
-Into `<strong>`{=html}subcutaneous`</strong>`{=html} tissue: V
+Into `<strong>subcutaneous`</strong> tissue: V
 </p>
 </li>
 <li>
@@ -919,8 +919,8 @@ Unknown Primary -- patients with N2,N3 disease
 </li>
 <li>
 <p>
-`<strong>`{=html}Patients with positive margins or lymph nodes that have
-ECS`</strong>`{=html}
+`<strong>Patients with positive margins or lymph nodes that have
+ECS`</strong>
 </p>
 </li>
 </ul>
@@ -949,7 +949,7 @@ Classic training is that if risk of spread to lymph nodes is
 \>15-25%, should do neck dissection
 </p>
 <p>
-`<strong>`{=html}N0 disease in:`</strong>`{=html}
+`<strong>N0 disease in:`</strong>
 </p>
 <ul>
 <li>
@@ -977,7 +977,7 @@ Subglottic - II-IV and VI
 Oral Cavity CA
 </h3>
 <p>
-`<strong>`{=html}Management`</strong>`{=html}
+`<strong>Management`</strong>
 </p>
 <ul>
 <li>
@@ -1015,7 +1015,7 @@ margins, ECS on LNs)
 Oropharyngeal CA
 </h3>
 <p>
-`<strong>`{=html}Sites`</strong>`{=html}:
+`<strong>Sites`</strong>:
 </p>
 <ul>
 <li>
@@ -1061,8 +1061,8 @@ Glottic Lesions
 <ul>
 <li>
 <p>
-Hyperplasia/Hyperkeratosis - `<u>`{=html}not a risk for
-malignancy`</u>`{=html}
+Hyperplasia/Hyperkeratosis - `<u>not a risk for
+malignancy`</u>
 </p>
 </li>
 <li>
@@ -1077,8 +1077,8 @@ Severe dysplasia/Carcinoma in situ- risk is 15-25%
 </li>
 <li>
 <p>
-CIS has features of malignancy but `<u>`{=html}not invaded beyond basement
-membrane`</u>`{=html}
+CIS has features of malignancy but `<u>not invaded beyond basement
+membrane`</u>
 </p>
 </li>
 <li>
@@ -1089,7 +1089,7 @@ Excisions
 <li>
 <p>
 Microflap excision: Dissects superficial lamina propria and
-`<u>`{=html}spares vocal ligament`</u>`{=html}
+`<u>spares vocal ligament`</u>
 </p>
 </li>
 </ul>
@@ -1105,7 +1105,7 @@ the larynx
 </li>
 <li>
 <p>
-`<strong>`{=html}Piriform sinus`</strong>`{=html} is most common location
+`<strong>Piriform sinus`</strong> is most common location
 </p>
 <ul>
 <li>
@@ -1145,7 +1145,7 @@ Techniques
 <ul>
 <li>
 <p>
-`<strong>`{=html}Partial laryngopharyngectomy`</strong>`{=html}
+`<strong>Partial laryngopharyngectomy`</strong>
 </p>
 <ul>
 <li>
@@ -1155,18 +1155,18 @@ For T1 (some T2) piriform sinus cancer
 </li>
 <li>
 <p>
-Must involve `<strong>`{=html}medial wall`</strong>`{=html} and be `<strong>`{=html}1.5cm
-away from apex`</strong>`{=html}
+Must involve `<strong>medial wall`</strong> and be `<strong>1.5cm
+away from apex`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Lateral + suprahyoid pharyngectomy`</strong>`{=html}
+`<strong>Lateral + suprahyoid pharyngectomy`</strong>
 </p>
 <ul>
 <li>
 <p>
-For `<u>`{=html}posterior`</u>`{=html} cricopharyngeal wall CA
+For `<u>posterior`</u> cricopharyngeal wall CA
 </p>
 </li>
 <li>
@@ -1176,7 +1176,7 @@ Total laryngectomy with partial pharyngectomy
 <ul>
 <li>
 <p>
-For advance CA and `<u>`{=html}post-cricoid`</u>`{=html} CA
+For advance CA and `<u>post-cricoid`</u> CA
 </p>
 </li>
 <li>
@@ -1197,13 +1197,13 @@ Sites
 <ul>
 <li>
 <p>
-`<strong>`{=html}Supraglottis`</strong>`{=html}: High rate of note metastasis.
+`<strong>Supraglottis`</strong>: High rate of note metastasis.
 Typically to bilateral II-IV
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Glottis`</strong>`{=html}: Most common site in larynx
+`<strong>Glottis`</strong>: Most common site in larynx
 </p>
 <ul>
 <li>
@@ -1214,13 +1214,13 @@ ligament)
 </li>
 <li>
 <p>
-Anterior commissure - `<u>`{=html}no inner perichondrium`</u>`{=html} allows for
+Anterior commissure - `<u>no inner perichondrium`</u> allows for
 anterior spread to thyroid cartilage
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Subglottic`</strong>`{=html}: Rare, poor prognosis
+`<strong>Subglottic`</strong>: Rare, poor prognosis
 </p>
 </li>
 <li>
@@ -1241,7 +1241,7 @@ scarring
 </li>
 <li>
 <p>
-`<strong>`{=html}Anterior commissure involvement`</strong>`{=html} - associated
+`<strong>Anterior commissure involvement`</strong> - associated
 with high recurrence rates
 </p>
 </li>
@@ -1252,8 +1252,8 @@ Surgery
 <ul>
 <li>
 <p>
-Cordectomy---Indication: T1 glottic cancer restricted to `<u>`{=html}middle
-1/3 of vocal fold`</u>`{=html}
+Cordectomy---Indication: T1 glottic cancer restricted to `<u>middle
+1/3 of vocal fold`</u>
 </p>
 </li>
 <li>
@@ -1278,8 +1278,8 @@ high risk of aspiration, must have really go pulmonary
 <ul>
 <li>
 <p>
-Can decrease risk by `<strong>`{=html}turning to operated side`</strong>`{=html}
-and performing a `<strong>`{=html}chin tuck`</strong>`{=html}
+Can decrease risk by `<strong>turning to operated side`</strong>
+and performing a `<strong>chin tuck`</strong>
 </p>
 </li>
 <li>
@@ -1296,7 +1296,7 @@ Hemi-laryngectomy)
 <ul>
 <li>
 <p>
-For `<strong>`{=html}T1/T2 `<em>`{=html}supraglottic`</em>`{=html} tumors`</strong>`{=html}
+For `<strong>T1/T2 `<em>supraglottic`</em> tumors`</strong>
 </p>
 </li>
 <li>
@@ -1318,7 +1318,7 @@ Supracricoid partial laryngectomy
 <ul>
 <li>
 <p>
-Must preserve `<u>`{=html}one functional cricoarytenoid unit`</u>`{=html}
+Must preserve `<u>one functional cricoarytenoid unit`</u>
 (arytenoid, cricoid and hyoid and associated musculature, plus the
 superior and recurrent laryngeal nerve)
 </p>
@@ -1331,8 +1331,8 @@ paraglottic space
 </li>
 <li>
 <p>
-`<strong>`{=html}Select T3/T3 supraglottic/glottic CA`</strong>`{=html} - must not
-have `<strong>`{=html}arytenoid fixation`</strong>`{=html}
+`<strong>Select T3/T3 supraglottic/glottic CA`</strong> - must not
+have `<strong>arytenoid fixation`</strong>
 </p>
 </li>
 <li>
@@ -1343,12 +1343,12 @@ cases
 </li>
 <li>
 <p>
-`<strong>`{=html}Contraindications`</strong>`{=html}:
+`<strong>Contraindications`</strong>:
 </p>
 <ul>
 <li>
 <p>
-Cartilage invasion, `<strong>`{=html}VF fixation`</strong>`{=html}, interarytenoid
+Cartilage invasion, `<strong>VF fixation`</strong>, interarytenoid
 involvement, tongue base involvement, poor performance status
 </p>
 </li>
@@ -1442,7 +1442,7 @@ Dr.
 Tracy's Radial Forearm Free Flap
 </h3>
 <p>
-`<strong>`{=html}Raising the flap`</strong>`{=html}
+`<strong>Raising the flap`</strong>
 </p>
 <p>
 Prep:
@@ -1604,7 +1604,7 @@ necessarily go hunting for the nerve
 Dr Wein INSPIRE Hypoglossal Nerve Implants
 </h3>
 <p>
-`<strong>`{=html}Set Up:`</strong>`{=html}
+`<strong>Set Up:`</strong>
 </p>
 <ul>
 <li>
@@ -1614,8 +1614,8 @@ Patient rotated 180. Tube taped to the left
 </li>
 <li>
 <p>
-Place shoulder roll. Tuck right arm. `<u>`{=html}Leave mouth
-open`</u>`{=html}
+Place shoulder roll. Tuck right arm. `<u>Leave mouth
+open`</u>
 </p>
 </li>
 <li>
@@ -1636,13 +1636,13 @@ Lead 3 (purple) goes into marginal mandibular
 </li>
 </ul>
 <p>
-`<img alt="" src="media/image29.png" style="width:3.68368in;height:1.27878in"/>`{=html}
+`<img alt="" src="media/image29.png" style="width:3.68368in;height:1.27878in"/>
 </p>
 <p>
 Figure 11: INSPIRE Implant Training, 2016
 </p>
 <p>
-`<strong>`{=html}Incisions:`</strong>`{=html}
+`<strong>Incisions:`</strong>
 </p>
 <p>
 Neck: 4-6cm starting from anterior aspect of submandibular gland to
@@ -1656,15 +1656,15 @@ Implant Pocket: 5cm inferior to clavicle. 5.5cm in length. Between
 deltopectoral groove & sternum
 </p>
 <p>
-Sensor: Use inferolateral margin of pec (should be 5`<sup>`{=html}th`</sup>`{=html}
+Sensor: Use inferolateral margin of pec (should be 5`<sup>th`</sup>
 intercostal space)
 </p>
 <p>
-`<img alt="" src="media/image30.png" style="width:2.25694in;height:1.55625in"/>`{=html} 4-5cm incision lateral to
+`<img alt="" src="media/image30.png" style="width:2.25694in;height:1.55625in"/> 4-5cm incision lateral to
 nipple line
 </p>
 <p>
-`<strong>`{=html}Prep`</strong>`{=html}
+`<strong>Prep`</strong>
 </p>
 <ul>
 <li>
@@ -1692,10 +1692,10 @@ top of 1000 drape (allow tongue to still be visible
 </li>
 </ul>
 <p>
-`<strong>`{=html}Steps:`</strong>`{=html}
+`<strong>Steps:`</strong>
 </p>
 <p>
-`<strong>`{=html}Neck`</strong>`{=html}: Incision through past platysma. Watch out for
+`<strong>Neck`</strong>: Incision through past platysma. Watch out for
 marginal mandibular (its just under platysma). Dissect to find
 mylohyoid/digastric tendon junction. If you first find the ant. belly of
 digastric, follow it posteriorly to digastric tendon. Then tunnel under
@@ -1714,7 +1714,7 @@ Pass stimulator under digastric tendon then tie stimulation lead to
 anterior belly of digastric. Pack w/ baci-soaked gauze
 </p>
 <p>
-`<strong>`{=html}Implant Pocket`</strong>`{=html}: Incision down to but not through pec
+`<strong>Implant Pocket`</strong>: Incision down to but not through pec
 major fascia. Dissect pocket inferiorly to about 6cm deep
 </p>
 <p>
@@ -1722,7 +1722,7 @@ Throw 2 silk sutures on medial edge of incision one 1cm superior to
 the other (vertical plane)
 </p>
 <p>
-`<strong>`{=html}Sensor lead`</strong>`{=html}: Incision on 5th intercostal space.
+`<strong>Sensor lead`</strong>: Incision on 5th intercostal space.
 Serratus fibers = most superficial running lateral to medial (inserting
 on ribs). External intercostals: run superior/lateral to inferior/medial
 (looks like packing tape). Make incision on medial aspect of incision
@@ -1735,7 +1735,7 @@ Use malleable to dissect plane btw ext & int intercostals
 intercostals w/ 4x 3-0 silk on RB-1
 </p>
 <p>
-`<strong>`{=html}Tunnels:`</strong>`{=html} Use tunneling shaft from neck incision to
+`<strong>Tunnels:`</strong> Use tunneling shaft from neck incision to
 implant incision (avoid ext jugular) in the subplatysmal plane. Then
 tunnel from implant incision above pectoralis to sensor lead incision.
 Pass sensor leads from neck and chest sensors to implant. Put leads into
@@ -1749,7 +1749,7 @@ parallel to incision to hide any blood stains. Unmarked 4x8 Gauze over
 incision taped down with Medipore tape
 </p>
 <p>
-`<strong>`{=html}Post-op`</strong>`{=html}
+`<strong>Post-op`</strong>
 </p>
 <p>
 No antibiotics
@@ -1761,8 +1761,8 @@ Pain medication
 Give post-INSPIRE d/c instructions
 </p>
 <p>
-Get `<u>`{=html}Lateral Neck and CXR in PACU. Make sure patient has no
-PTX`</u>`{=html}
+Get `<u>Lateral Neck and CXR in PACU. Make sure patient has no
+PTX`</u>
 </p>
 <h2 class="unnumbered" id="head-neck-post-op-guide">
 Head & Neck --
@@ -1814,7 +1814,7 @@ Generic Free Flap
 \[Tracy\]
 </h3>
 <p>
-`<strong>`{=html}Neuro:`</strong>`{=html}
+`<strong>Neuro:`</strong>
 </p>
 <ul>
 <li>
@@ -1828,7 +1828,7 @@ No NSAIDs until POD#7
 </li>
 </ul>
 <p>
-`<strong>`{=html}HEENT:`</strong>`{=html}
+`<strong>HEENT:`</strong>
 </p>
 <ul>
 <li>
@@ -1851,7 +1851,7 @@ No circumferential neck ties
 </li>
 </ul>
 <p>
-`<strong>`{=html}CV:`</strong>`{=html}
+`<strong>CV:`</strong>
 </p>
 <ul>
 <li>
@@ -1862,7 +1862,7 @@ Avoid pressors as much as possible, please give fluid boluses or transfuse with 
 </li>
 </ul>
 <p>
-`<strong>`{=html}RESP:`</strong>`{=html}
+`<strong>RESP:`</strong>
 </p>
 <ul>
 <li>
@@ -1873,7 +1873,7 @@ In the event of decannulation, pull the stay sutures towards the skin to bring t
 </li>
 </ul>
 <p>
-`<strong>`{=html}GI:`</strong>`{=html}
+`<strong>GI:`</strong>
 </p>
 <ul>
 <li>
@@ -1893,7 +1893,7 @@ STRICT NPO. No swabs or ice chips.
 </li>
 </ul>
 <p>
-`<strong>`{=html}ID:`</strong>`{=html}
+`<strong>ID:`</strong>
 </p>
 <ul>
 <li>
@@ -1910,7 +1910,7 @@ Bacitracin to incisions BID
 </li>
 </ul>
 <p>
-`<strong>`{=html}GU:`</strong>`{=html}
+`<strong>GU:`</strong>
 </p>
 <ul>
 <li>
@@ -1921,7 +1921,7 @@ Remove foley when able
 </li>
 </ul>
 <p>
-`<strong>`{=html}HEME:`</strong>`{=html}
+`<strong>HEME:`</strong>
 </p>
 <ul>
 <li>
@@ -1932,7 +1932,7 @@ CBC daily
 </li>
 </ul>
 <p>
-`<strong>`{=html}MSK:`</strong>`{=html}
+`<strong>MSK:`</strong>
 </p>
 <ul>
 <li>
@@ -2005,7 +2005,7 @@ place back into stoma
 </li>
 <li>
 <p>
-Rounds: `<strong>`{=html}`<u>`{=html}check for crusting in the stoma`</u>`{=html}`</strong>`{=html} --
+Rounds: `<strong>`<u>check for crusting in the stoma`</u>`</strong> --
 any exposed cartilage? In radiated patients, look out for possible
 fistula formation (tube feeds coming out neck)
 </p>
@@ -2023,8 +2023,8 @@ q4-6hours. If normal, recheck iCa2+ q8hrs.
 </li>
 <li>
 <p>
-levothyroxine: according to endocrine, `<strong>`{=html}levothyroxine dose
-in mcg = 1.7xpt's weight (kg)`</strong>`{=html}
+levothyroxine: according to endocrine, `<strong>levothyroxine dose
+in mcg = 1.7xpt's weight (kg)`</strong>
 </p>
 </li>
 <li>
@@ -2074,14 +2074,14 @@ requirement).
 </li>
 <li>
 <p>
-`<strong>`{=html}Before trach change`</strong>`{=html}: ask RT to put new trachs at
+`<strong>Before trach change`</strong>: ask RT to put new trachs at
 bedside and ask the RN to verify the correct type is there. Also ask the
 RN to give some pain medication just before change.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Need`</strong>`{=html}: shoulder roll, headlight, new trach, 10cc
+`<strong>Need`</strong>: shoulder roll, headlight, new trach, 10cc
 syringe, lube, suture scissors, suction set up in room, flexible
 'chimney' suction, yankeur suction, 4x4 gauze w/ saline, Velcro trach
 tie, allvyn dressing (prn)
@@ -2089,7 +2089,7 @@ tie, allvyn dressing (prn)
 </li>
 <li>
 <p>
-After 1`<sup>`{=html}st`</sup>`{=html} trach change: RT can change the
+After 1`<sup>st`</sup> trach change: RT can change the
 trach
 </p>
 </li>
@@ -2121,7 +2121,7 @@ High output \>500cc/day: typically need to go to OR.
 </p>
 <h2 class="unnumbered" id="head-neck-staging---8th-edition">
 Head &
-Neck Staging - 8`<sup>`{=html}th`</sup>`{=html} Edition
+Neck Staging - 8`<sup>th`</sup> Edition
 </h2>
 <ul>
 <li>
@@ -2187,21 +2187,21 @@ N1
 </p>
 </td>
 <td>
-`<strong>`{=html}Single`</strong>`{=html} ipsilateral, \<3cm,
-ENE`<sub>`{=html}negative`</sub>`{=html}
+`<strong>Single`</strong> ipsilateral, \<3cm,
+ENE`<sub>negative`</sub>
 </td>
 <td>
 N2
 </td>
 <td>
 <p>
-N2`<sub>`{=html}ALL`</sub>`{=html}: \<6cm, ENE`<sub>`{=html}negative`</sub>`{=html}
+N2`<sub>ALL`</sub>: \<6cm, ENE`<sub>negative`</sub>
 </p>
 <p>
 N2a: single, ipsilateral
 </p>
 <p>
-N2b: `<strong>`{=html}multiple,`</strong>`{=html} ipsilateral
+N2b: `<strong>multiple,`</strong> ipsilateral
 </p>
 <p>
 N2c: bilateral/contralateral
@@ -2215,7 +2215,7 @@ N3
 N3a: \>6cm
 </p>
 <p>
-N3b: ENE`<sub>`{=html}positive`</sub>`{=html}
+N3b: ENE`<sub>positive`</sub>
 </p>
 </td>
 <li>
@@ -2229,7 +2229,7 @@ For Nasopharyngeal and P16 positive
 HPV Positive
 </th>
 <td>
-ipsilateral `<strong>`{=html}\<6cm`</strong>`{=html}
+ipsilateral `<strong>\<6cm`</strong>
 </td>
 <td>
 Contralateral/bilateral \<6cm
@@ -2368,17 +2368,17 @@ Skull base
 Carotid
 </p>
 <p>
-\*note similarities to T4b of p16`<sub>`{=html}neg`</sub>`{=html} OPC
+\*note similarities to T4b of p16`<sub>neg`</sub> OPC
 </p>
 </td>
 <p>
-`<img alt="" src="media/image31.emf" style="width:1.79653in;height:1.52526in"/>`{=html} 
+`<img alt="" src="media/image31.emf" style="width:1.79653in;height:1.52526in"/> 
 </p>
 <h3 class="unnumbered" id="oropharyngeal">
 OROPHARYNGEAL
 </h3>
 <p>
-`<strong>`{=html}HPV Neg (p16-) and HPV Pos`</strong>`{=html}
+`<strong>HPV Neg (p16-) and HPV Pos`</strong>
 </p>
 <col style="width: 16%"/>
 <col style="width: 43%"/>
@@ -2441,10 +2441,10 @@ Mandible
 </ul>
 <td>
 <p>
-`<strong>`{=html}T4a`</strong>`{=html} - Same
+`<strong>T4a`</strong> - Same
 </p>
 <p>
-`<strong>`{=html}T4b`</strong>`{=html} - Invades
+`<strong>T4b`</strong> - Invades
 </p>
 <ul>
 <li>
@@ -2478,8 +2478,8 @@ Clinical N staging
 <col style="width: 38%"/>
 <col style="width: 42%"/>
 <p>
-`<strong>`{=html}Note: ECE`</strong>`{=html} automatically `<strong>`{=html}bumps you up a N
-stage in the `<u>`{=html}pathological N grading system`</u>`{=html}`</strong>`{=html} (not
+`<strong>Note: ECE`</strong> automatically `<strong>bumps you up a N
+stage in the `<u>pathological N grading system`</u>`</strong> (not
 shown).
 </p>
 <p>
@@ -2637,7 +2637,7 @@ Mediastinum
 </li>
 </ul>
 <p>
-`<img alt="" src="media/image32.png" style="width:1.85124in;height:1.97204in"/>`{=html} 
+`<img alt="" src="media/image32.png" style="width:1.85124in;height:1.97204in"/> 
 </p>
 <p>
 In general, for Laryngeal Cancer
@@ -2773,7 +2773,7 @@ Cannot extend to esophageus or cause VF fixation
 </p>
 </td>
 <td>
-\>4cm OR invades `<strong>`{=html}esophageus`</strong>`{=html} OR causes VF
+\>4cm OR invades `<strong>esophageus`</strong> OR causes VF
 fixation
 </td>
 <ul>
@@ -2895,14 +2895,14 @@ Nasopharynx
  NASOPHARYNGEAL CA
 </h3>
 <p>
-`<strong>`{=html}WHO Type I`</strong>`{=html} - Keratinizing SCCA
+`<strong>WHO Type I`</strong> - Keratinizing SCCA
 </p>
 <p>
-`<strong>`{=html}WHO Type II`</strong>`{=html} - Nonkerating SCCA (associated with EBV,
+`<strong>WHO Type II`</strong> - Nonkerating SCCA (associated with EBV,
 better prognosis)
 </p>
 <p>
-`<strong>`{=html}WHO Type III`</strong>`{=html} - Undifferentiated CA
+`<strong>WHO Type III`</strong> - Undifferentiated CA
 </p>
 <td>
 Nasopharynx/nasal cavity
@@ -3039,7 +3039,7 @@ T4b: invading into carotid/mediastinum/RLN
 Thyroid cancer staging
 </p>
 <p>
-`<strong>`{=html}Only `<u>`{=html}\>55 years old`</u>`{=html}`</strong>`{=html}: those \<55yo are
+`<strong>Only `<u>\>55 years old`</u>`</strong>: those \<55yo are
 Stage I unless they have mets, then they are stage II
 </p>
 <p>
@@ -3065,34 +3065,34 @@ etc)
 <col style="width: 22%"/>
 <col style="width: 77%"/>
 <th>
- `<em>`{=html}T category`</em>`{=html}
+ `<em>T category`</em>
 </th>
 <td>
-`<em>`{=html}T1`</em>`{=html}
+`<em>T1`</em>
 </td>
 <td>
 \<2cm
 </td>
 <td>
-`<em>`{=html}T2`</em>`{=html}
+`<em>T2`</em>
 </td>
 <td>
 <p>
 2-4cm
 </p>
 <td>
-`<em>`{=html}T3`</em>`{=html}
+`<em>T3`</em>
 </td>
 <td>
-\>4cm or `<strong>`{=html}DOI \>6mm`</strong>`{=html} or Perineural/minor bone
+\>4cm or `<strong>DOI \>6mm`</strong> or Perineural/minor bone
 invasion
 </td>
 <td>
 <p>
-`<em>`{=html}T4a`</em>`{=html}
+`<em>T4a`</em>
 </p>
 <p>
-`<em>`{=html}T4b`</em>`{=html}
+`<em>T4b`</em>
 </p>
 </td>
 <td>
@@ -3110,10 +3110,10 @@ Tumor with skull base/foramina invasion
  MELANOMA (SKIN)
 </h3>
 <p>
- `<strong>`{=html}a/b/c classification`</strong>`{=html}
+ `<strong>a/b/c classification`</strong>
 </p>
 <p>
-T stage: IF `<strong>`{=html}ulceration`</strong>`{=html} stage is `<strong>`{=html}B`</strong>`{=html}
+T stage: IF `<strong>ulceration`</strong> stage is `<strong>B`</strong>
 (as in T2-\>T2b)
 </p>
 <p>
@@ -3161,7 +3161,7 @@ N stage
             </p>
             </td>
             <td>
-            `<strong>`{=html}N1`</strong>`{=html}
+            `<strong>N1`</strong>
             </td>
             <td>
             1 node
@@ -3171,7 +3171,7 @@ N stage
             1-2mm thick
             </p>
             <td>
-            `<strong>`{=html}N2`</strong>`{=html}
+            `<strong>N2`</strong>
             </td>
             <td>
             2-3 nodes
@@ -3180,7 +3180,7 @@ N stage
             2-4mm thick
             </td>
             <td>
-            `<strong>`{=html}N3`</strong>`{=html}
+            `<strong>N3`</strong>
             </td>
             <td>
             4+ nodes, matted nodes, or in transit mets
@@ -3214,7 +3214,7 @@ N stage
             </p>
             </td>
             <td>
-            `<strong>`{=html}M1`</strong>`{=html}
+            `<strong>M1`</strong>
             </td>
             <td>
             Any mets
@@ -3224,10 +3224,10 @@ N stage
             prevertebral space
             </td>
             <p>
-            `<img alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " src="media/image33.png" style="width:1.88969in;height:2.90093in"/>`{=html}
+            `<img alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " src="media/image33.png" style="width:1.88969in;height:2.90093in"/>
             </p>
             <p>
-            `<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+            `<a href="index.html">Back to homepage`</a>
             </p>
             </td>
             </td>

--- a/head-and-neck-surgery/clinic-guide.md
+++ b/head-and-neck-surgery/clinic-guide.md
@@ -83,7 +83,7 @@ Similar to Dr. O'Leary's clinic flow
 Burning Mouth Consults
 </h3>
 <p>
-`<em>`{=html}Dr. O'Leary's workup`</em>`{=html}
+`<em>Dr. O'Leary's workup`</em>
 </p>
 <ul>
 <li>
@@ -180,20 +180,20 @@ Initial workup of palpable or incidentally found nodules 
 <ul>
 <li>
 <p>
-`<strong>`{=html}TSH `</strong>`{=html}\[Free T`<sub>`{=html}4`</sub>`{=html}\]
-and `<strong>`{=html}Ultrasound `</strong>`{=html} 
+`<strong>TSH `</strong>\[Free T`<sub>4`</sub>\]
+and `<strong>Ultrasound `</strong> 
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Normal or high TSH`</strong>`{=html} → no need for reuptake
+`<strong>Normal or high TSH`</strong> → no need for reuptake
 radionuclide cscan 
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Low`</strong>`{=html} TSH → get a Iodine`<sup>`{=html}123`</sup>`{=html} or
-Technetium`<sup>`{=html}99`</sup>`{=html} reuptake scan 
+`<strong>Low`</strong> TSH → get a Iodine`<sup>123`</sup> or
+Technetium`<sup>99`</sup> reuptake scan 
 </p>
 <ol type="1">
 <li>
@@ -214,7 +214,7 @@ Multiple nodules? Evaluate each one separately. 
 <ul>
 <li>
 <p>
-If TSH low or normal. Get I`<sup>`{=html}123`</sup>`{=html} scan to see if there
+If TSH low or normal. Get I`<sup>123`</sup> scan to see if there
 are autonomous nodules  
 </p>
 </li>
@@ -235,7 +235,7 @@ Don't bother if its completely cystic 
 </li>
 <li>
 <p>
-Perform FNA if nodule is (A) \>2cm `<strong>`{=html} or `</strong>`{=html}(B) 
+Perform FNA if nodule is (A) \>2cm `<strong> or `</strong>(B) 
 \>1cm + suspicious features 
 </p>
 </li>
@@ -246,7 +246,7 @@ Suspicious Ultrasound features (70% chance of malignancy) 
 <ul>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Hypo`</u>`{=html}`</strong>`{=html}echoic - think hypOH DEAR ITS
+`<strong>`<u>Hypo`</u>`</strong>echoic - think hypOH DEAR ITS
 CANCER 
 </p>
 <ul>
@@ -447,8 +447,8 @@ exist
 <li>
 <p>
 Suspicious if: present for \>2 weeks w/o change in size
-`<u>`{=html}or`</u>`{=html} if on exam mass is (1) fixed to adjacent structure (2) firm
-(3) \>1.5cm or (4) has ulceration of overlying skin `<u>`{=html}or`</u>`{=html} history
+`<u>or`</u> if on exam mass is (1) fixed to adjacent structure (2) firm
+(3) \>1.5cm or (4) has ulceration of overlying skin `<u>or`</u> history
 highly suspicious
 </p>
 <ul>
@@ -480,7 +480,7 @@ If testing is negative:
 <ul>
 <li>
 <p>
-Can either with open biopsy (should `<u>`{=html}always`</u>`{=html} be done with a
+Can either with open biopsy (should `<u>always`</u> be done with a
 direct laryngoscopy)
 </p>
 </li>
@@ -658,32 +658,32 @@ High rate of recurrence
 </li>
 <li>
 <p>
-Clark levels: `<u>`{=html}only useful for prognosis in T1 lesions.`</u>`{=html}
+Clark levels: `<u>only useful for prognosis in T1 lesions.`</u>
 </p>
 <ul>
 <li>
 <p>
-`<strong>`{=html}epidermis`</strong>`{=html} only = stage I.
+`<strong>epidermis`</strong> only = stage I.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Into papillary`</strong>`{=html} dermis = II.
+`<strong>Into papillary`</strong> dermis = II.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}All of papillary`</strong>`{=html} dermis =III.
+`<strong>All of papillary`</strong> dermis =III.
 </p>
 </li>
 <li>
 <p>
-Invades `<strong>`{=html}reticular`</strong>`{=html} dermis = IV.
+Invades `<strong>reticular`</strong> dermis = IV.
 </p>
 </li>
 <li>
 <p>
-Into `<strong>`{=html}subcutaneous`</strong>`{=html} tissue: V
+Into `<strong>subcutaneous`</strong> tissue: V
 </p>
 </li>
 <li>
@@ -870,7 +870,7 @@ of the hottest node.
 </li>
 </ul>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/head-and-neck-surgery/follow-up-guide.md
+++ b/head-and-neck-surgery/follow-up-guide.md
@@ -51,7 +51,7 @@ Evals: SLP, dental, and nutrition evals as needed
 </li>
 </ul>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/head-and-neck-surgery/index.md
+++ b/head-and-neck-surgery/index.md
@@ -4,21 +4,21 @@ title: Head &amp; Neck Surgery
 ---
 <ul>
 <li>
-`<a href="clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="squamous-cell-carcinoma.html">`{=html}Squamous Cell Carcinoma`</a>`{=html}
+`<a href="squamous-cell-carcinoma.html">Squamous Cell Carcinoma`</a>
 </li>
 <li>
-`<a href="follow-up-guide.html">`{=html}Post-H&N Cancer Follow-up Guide`</a>`{=html}
+`<a href="follow-up-guide.html">Post-H&N Cancer Follow-up Guide`</a>
 </li>
 <li>
-`<a href="or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="or-guide.html">OR Guide`</a>
 </li>
 <li>
-`<a href="post-op-guide.html">`{=html}Post-op Guide`</a>`{=html}
+`<a href="post-op-guide.html">Post-op Guide`</a>
 </li>
 <li>
-`<a href="staging-8th-edition.html">`{=html}Staging - 8th Edition`</a>`{=html}
+`<a href="staging-8th-edition.html">Staging - 8th Edition`</a>
 </li>
 </ul>

--- a/head-and-neck-surgery/or-guide.md
+++ b/head-and-neck-surgery/or-guide.md
@@ -11,7 +11,7 @@ Dr.
 Tracy's Radial Forearm Free Flap
 </h3>
 <p>
-`<strong>`{=html}Raising the flap`</strong>`{=html}
+`<strong>Raising the flap`</strong>
 </p>
 <p>
 Prep:
@@ -173,7 +173,7 @@ necessarily go hunting for the nerve
 Dr Wein INSPIRE Hypoglossal Nerve Implants
 </h3>
 <p>
-`<strong>`{=html}Set Up:`</strong>`{=html}
+`<strong>Set Up:`</strong>
 </p>
 <ul>
 <li>
@@ -183,8 +183,8 @@ Patient rotated 180. Tube taped to the left
 </li>
 <li>
 <p>
-Place shoulder roll. Tuck right arm. `<u>`{=html}Leave mouth
-open`</u>`{=html}
+Place shoulder roll. Tuck right arm. `<u>Leave mouth
+open`</u>
 </p>
 </li>
 <li>
@@ -205,13 +205,13 @@ Lead 3 (purple) goes into marginal mandibular
 </li>
 </ul>
 <p>
-`<img alt="" src="../media/image29.png" style="width:3.68368in;height:1.27878in"/>`{=html}
+`<img alt="" src="../media/image29.png" style="width:3.68368in;height:1.27878in"/>
 </p>
 <p>
 Figure 11: INSPIRE Implant Training, 2016
 </p>
 <p>
-`<strong>`{=html}Incisions:`</strong>`{=html}
+`<strong>Incisions:`</strong>
 </p>
 <p>
 Neck: 4-6cm starting from anterior aspect of submandibular gland to
@@ -225,15 +225,15 @@ Implant Pocket: 5cm inferior to clavicle. 5.5cm in length. Between
 deltopectoral groove & sternum
 </p>
 <p>
-Sensor: Use inferolateral margin of pec (should be 5`<sup>`{=html}th`</sup>`{=html}
+Sensor: Use inferolateral margin of pec (should be 5`<sup>th`</sup>
 intercostal space)
 </p>
 <p>
-`<img alt="" src="../media/image30.png" style="width:2.25694in;height:1.55625in"/>`{=html} 4-5cm incision lateral to
+`<img alt="" src="../media/image30.png" style="width:2.25694in;height:1.55625in"/> 4-5cm incision lateral to
 nipple line
 </p>
 <p>
-`<strong>`{=html}Prep`</strong>`{=html}
+`<strong>Prep`</strong>
 </p>
 <ul>
 <li>
@@ -261,10 +261,10 @@ top of 1000 drape (allow tongue to still be visible
 </li>
 </ul>
 <p>
-`<strong>`{=html}Steps:`</strong>`{=html}
+`<strong>Steps:`</strong>
 </p>
 <p>
-`<strong>`{=html}Neck`</strong>`{=html}: Incision through past platysma. Watch out for
+`<strong>Neck`</strong>: Incision through past platysma. Watch out for
 marginal mandibular (its just under platysma). Dissect to find
 mylohyoid/digastric tendon junction. If you first find the ant. belly of
 digastric, follow it posteriorly to digastric tendon. Then tunnel under
@@ -283,7 +283,7 @@ Pass stimulator under digastric tendon then tie stimulation lead to
 anterior belly of digastric. Pack w/ baci-soaked gauze
 </p>
 <p>
-`<strong>`{=html}Implant Pocket`</strong>`{=html}: Incision down to but not through pec
+`<strong>Implant Pocket`</strong>: Incision down to but not through pec
 major fascia. Dissect pocket inferiorly to about 6cm deep
 </p>
 <p>
@@ -291,7 +291,7 @@ Throw 2 silk sutures on medial edge of incision one 1cm superior to
 the other (vertical plane)
 </p>
 <p>
-`<strong>`{=html}Sensor lead`</strong>`{=html}: Incision on 5th intercostal space.
+`<strong>Sensor lead`</strong>: Incision on 5th intercostal space.
 Serratus fibers = most superficial running lateral to medial (inserting
 on ribs). External intercostals: run superior/lateral to inferior/medial
 (looks like packing tape). Make incision on medial aspect of incision
@@ -304,7 +304,7 @@ Use malleable to dissect plane btw ext & int intercostals
 intercostals w/ 4x 3-0 silk on RB-1
 </p>
 <p>
-`<strong>`{=html}Tunnels:`</strong>`{=html} Use tunneling shaft from neck incision to
+`<strong>Tunnels:`</strong> Use tunneling shaft from neck incision to
 implant incision (avoid ext jugular) in the subplatysmal plane. Then
 tunnel from implant incision above pectoralis to sensor lead incision.
 Pass sensor leads from neck and chest sensors to implant. Put leads into
@@ -318,7 +318,7 @@ parallel to incision to hide any blood stains. Unmarked 4x8 Gauze over
 incision taped down with Medipore tape
 </p>
 <p>
-`<strong>`{=html}Post-op`</strong>`{=html}
+`<strong>Post-op`</strong>
 </p>
 <p>
 No antibiotics
@@ -330,11 +330,11 @@ Pain medication
 Give post-INSPIRE d/c instructions
 </p>
 <p>
-Get `<u>`{=html}Lateral Neck and CXR in PACU. Make sure patient has no
-PTX`</u>`{=html}
+Get `<u>Lateral Neck and CXR in PACU. Make sure patient has no
+PTX`</u>
 </p>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/head-and-neck-surgery/post-op-guide.md
+++ b/head-and-neck-surgery/post-op-guide.md
@@ -52,7 +52,7 @@ Generic Free Flap
 \[Tracy\]
 </h3>
 <p>
-`<strong>`{=html}Neuro:`</strong>`{=html}
+`<strong>Neuro:`</strong>
 </p>
 <ul>
 <li>
@@ -66,7 +66,7 @@ No NSAIDs until POD#7
 </li>
 </ul>
 <p>
-`<strong>`{=html}HEENT:`</strong>`{=html}
+`<strong>HEENT:`</strong>
 </p>
 <ul>
 <li>
@@ -89,7 +89,7 @@ No circumferential neck ties
 </li>
 </ul>
 <p>
-`<strong>`{=html}CV:`</strong>`{=html}
+`<strong>CV:`</strong>
 </p>
 <ul>
 <li>
@@ -100,7 +100,7 @@ Avoid pressors as much as possible, please give fluid boluses or transfuse with 
 </li>
 </ul>
 <p>
-`<strong>`{=html}RESP:`</strong>`{=html}
+`<strong>RESP:`</strong>
 </p>
 <ul>
 <li>
@@ -111,7 +111,7 @@ In the event of decannulation, pull the stay sutures towards the skin to bring t
 </li>
 </ul>
 <p>
-`<strong>`{=html}GI:`</strong>`{=html}
+`<strong>GI:`</strong>
 </p>
 <ul>
 <li>
@@ -131,7 +131,7 @@ STRICT NPO. No swabs or ice chips.
 </li>
 </ul>
 <p>
-`<strong>`{=html}ID:`</strong>`{=html}
+`<strong>ID:`</strong>
 </p>
 <ul>
 <li>
@@ -148,7 +148,7 @@ Bacitracin to incisions BID
 </li>
 </ul>
 <p>
-`<strong>`{=html}GU:`</strong>`{=html}
+`<strong>GU:`</strong>
 </p>
 <ul>
 <li>
@@ -159,7 +159,7 @@ Remove foley when able
 </li>
 </ul>
 <p>
-`<strong>`{=html}HEME:`</strong>`{=html}
+`<strong>HEME:`</strong>
 </p>
 <ul>
 <li>
@@ -170,7 +170,7 @@ CBC daily
 </li>
 </ul>
 <p>
-`<strong>`{=html}MSK:`</strong>`{=html}
+`<strong>MSK:`</strong>
 </p>
 <ul>
 <li>
@@ -243,7 +243,7 @@ place back into stoma
 </li>
 <li>
 <p>
-Rounds: `<strong>`{=html}`<u>`{=html}check for crusting in the stoma`</u>`{=html}`</strong>`{=html} --
+Rounds: `<strong>`<u>check for crusting in the stoma`</u>`</strong> --
 any exposed cartilage? In radiated patients, look out for possible
 fistula formation (tube feeds coming out neck)
 </p>
@@ -261,8 +261,8 @@ q4-6hours. If normal, recheck iCa2+ q8hrs.
 </li>
 <li>
 <p>
-levothyroxine: according to endocrine, `<strong>`{=html}levothyroxine dose
-in mcg = 1.7xpt's weight (kg)`</strong>`{=html}
+levothyroxine: according to endocrine, `<strong>levothyroxine dose
+in mcg = 1.7xpt's weight (kg)`</strong>
 </p>
 </li>
 <li>
@@ -312,14 +312,14 @@ requirement).
 </li>
 <li>
 <p>
-`<strong>`{=html}Before trach change`</strong>`{=html}: ask RT to put new trachs at
+`<strong>Before trach change`</strong>: ask RT to put new trachs at
 bedside and ask the RN to verify the correct type is there. Also ask the
 RN to give some pain medication just before change.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Need`</strong>`{=html}: shoulder roll, headlight, new trach, 10cc
+`<strong>Need`</strong>: shoulder roll, headlight, new trach, 10cc
 syringe, lube, suture scissors, suction set up in room, flexible
 'chimney' suction, yankeur suction, 4x4 gauze w/ saline, Velcro trach
 tie, allvyn dressing (prn)
@@ -327,7 +327,7 @@ tie, allvyn dressing (prn)
 </li>
 <li>
 <p>
-After 1`<sup>`{=html}st`</sup>`{=html} trach change: RT can change the
+After 1`<sup>st`</sup> trach change: RT can change the
 trach
 </p>
 </li>
@@ -358,7 +358,7 @@ Medium chain triglyceride diet \[For tube feeds switch to Portagen\]
 High output \>500cc/day: typically need to go to OR.
 </p>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/head-and-neck-surgery/squamous-cell-carcinoma.md
+++ b/head-and-neck-surgery/squamous-cell-carcinoma.md
@@ -52,8 +52,8 @@ Unknown Primary -- patients with N2,N3 disease
 </li>
 <li>
 <p>
-`<strong>`{=html}Patients with positive margins or lymph nodes that have
-ECS`</strong>`{=html}
+`<strong>Patients with positive margins or lymph nodes that have
+ECS`</strong>
 </p>
 </li>
 </ul>
@@ -82,7 +82,7 @@ Classic training is that if risk of spread to lymph nodes is
 \>15-25%, should do neck dissection
 </p>
 <p>
-`<strong>`{=html}N0 disease in:`</strong>`{=html}
+`<strong>N0 disease in:`</strong>
 </p>
 <ul>
 <li>
@@ -110,7 +110,7 @@ Subglottic - II-IV and VI
 Oral Cavity CA
 </h3>
 <p>
-`<strong>`{=html}Management`</strong>`{=html}
+`<strong>Management`</strong>
 </p>
 <ul>
 <li>
@@ -148,7 +148,7 @@ margins, ECS on LNs)
 Oropharyngeal CA
 </h3>
 <p>
-`<strong>`{=html}Sites`</strong>`{=html}:
+`<strong>Sites`</strong>:
 </p>
 <ul>
 <li>
@@ -194,8 +194,8 @@ Glottic Lesions
 <ul>
 <li>
 <p>
-Hyperplasia/Hyperkeratosis - `<u>`{=html}not a risk for
-malignancy`</u>`{=html}
+Hyperplasia/Hyperkeratosis - `<u>not a risk for
+malignancy`</u>
 </p>
 </li>
 <li>
@@ -210,8 +210,8 @@ Severe dysplasia/Carcinoma in situ- risk is 15-25%
 </li>
 <li>
 <p>
-CIS has features of malignancy but `<u>`{=html}not invaded beyond basement
-membrane`</u>`{=html}
+CIS has features of malignancy but `<u>not invaded beyond basement
+membrane`</u>
 </p>
 </li>
 <li>
@@ -222,7 +222,7 @@ Excisions
 <li>
 <p>
 Microflap excision: Dissects superficial lamina propria and
-`<u>`{=html}spares vocal ligament`</u>`{=html}
+`<u>spares vocal ligament`</u>
 </p>
 </li>
 </ul>
@@ -238,7 +238,7 @@ the larynx
 </li>
 <li>
 <p>
-`<strong>`{=html}Piriform sinus`</strong>`{=html} is most common location
+`<strong>Piriform sinus`</strong> is most common location
 </p>
 <ul>
 <li>
@@ -278,7 +278,7 @@ Techniques
 <ul>
 <li>
 <p>
-`<strong>`{=html}Partial laryngopharyngectomy`</strong>`{=html}
+`<strong>Partial laryngopharyngectomy`</strong>
 </p>
 <ul>
 <li>
@@ -288,18 +288,18 @@ For T1 (some T2) piriform sinus cancer
 </li>
 <li>
 <p>
-Must involve `<strong>`{=html}medial wall`</strong>`{=html} and be `<strong>`{=html}1.5cm
-away from apex`</strong>`{=html}
+Must involve `<strong>medial wall`</strong> and be `<strong>1.5cm
+away from apex`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Lateral + suprahyoid pharyngectomy`</strong>`{=html}
+`<strong>Lateral + suprahyoid pharyngectomy`</strong>
 </p>
 <ul>
 <li>
 <p>
-For `<u>`{=html}posterior`</u>`{=html} cricopharyngeal wall CA
+For `<u>posterior`</u> cricopharyngeal wall CA
 </p>
 </li>
 <li>
@@ -309,7 +309,7 @@ Total laryngectomy with partial pharyngectomy
 <ul>
 <li>
 <p>
-For advance CA and `<u>`{=html}post-cricoid`</u>`{=html} CA
+For advance CA and `<u>post-cricoid`</u> CA
 </p>
 </li>
 <li>
@@ -330,13 +330,13 @@ Sites
 <ul>
 <li>
 <p>
-`<strong>`{=html}Supraglottis`</strong>`{=html}: High rate of note metastasis.
+`<strong>Supraglottis`</strong>: High rate of note metastasis.
 Typically to bilateral II-IV
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Glottis`</strong>`{=html}: Most common site in larynx
+`<strong>Glottis`</strong>: Most common site in larynx
 </p>
 <ul>
 <li>
@@ -347,13 +347,13 @@ ligament)
 </li>
 <li>
 <p>
-Anterior commissure - `<u>`{=html}no inner perichondrium`</u>`{=html} allows for
+Anterior commissure - `<u>no inner perichondrium`</u> allows for
 anterior spread to thyroid cartilage
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Subglottic`</strong>`{=html}: Rare, poor prognosis
+`<strong>Subglottic`</strong>: Rare, poor prognosis
 </p>
 </li>
 <li>
@@ -374,7 +374,7 @@ scarring
 </li>
 <li>
 <p>
-`<strong>`{=html}Anterior commissure involvement`</strong>`{=html} - associated
+`<strong>Anterior commissure involvement`</strong> - associated
 with high recurrence rates
 </p>
 </li>
@@ -385,8 +385,8 @@ Surgery
 <ul>
 <li>
 <p>
-Cordectomy---Indication: T1 glottic cancer restricted to `<u>`{=html}middle
-1/3 of vocal fold`</u>`{=html}
+Cordectomy---Indication: T1 glottic cancer restricted to `<u>middle
+1/3 of vocal fold`</u>
 </p>
 </li>
 <li>
@@ -411,8 +411,8 @@ high risk of aspiration, must have really go pulmonary
 <ul>
 <li>
 <p>
-Can decrease risk by `<strong>`{=html}turning to operated side`</strong>`{=html}
-and performing a `<strong>`{=html}chin tuck`</strong>`{=html}
+Can decrease risk by `<strong>turning to operated side`</strong>
+and performing a `<strong>chin tuck`</strong>
 </p>
 </li>
 <li>
@@ -429,7 +429,7 @@ Hemi-laryngectomy)
 <ul>
 <li>
 <p>
-For `<strong>`{=html}T1/T2 `<em>`{=html}supraglottic`</em>`{=html} tumors`</strong>`{=html}
+For `<strong>T1/T2 `<em>supraglottic`</em> tumors`</strong>
 </p>
 </li>
 <li>
@@ -451,7 +451,7 @@ Supracricoid partial laryngectomy
 <ul>
 <li>
 <p>
-Must preserve `<u>`{=html}one functional cricoarytenoid unit`</u>`{=html}
+Must preserve `<u>one functional cricoarytenoid unit`</u>
 (arytenoid, cricoid and hyoid and associated musculature, plus the
 superior and recurrent laryngeal nerve)
 </p>
@@ -464,8 +464,8 @@ paraglottic space
 </li>
 <li>
 <p>
-`<strong>`{=html}Select T3/T3 supraglottic/glottic CA`</strong>`{=html} - must not
-have `<strong>`{=html}arytenoid fixation`</strong>`{=html}
+`<strong>Select T3/T3 supraglottic/glottic CA`</strong> - must not
+have `<strong>arytenoid fixation`</strong>
 </p>
 </li>
 <li>
@@ -476,12 +476,12 @@ cases
 </li>
 <li>
 <p>
-`<strong>`{=html}Contraindications`</strong>`{=html}:
+`<strong>Contraindications`</strong>:
 </p>
 <ul>
 <li>
 <p>
-Cartilage invasion, `<strong>`{=html}VF fixation`</strong>`{=html}, interarytenoid
+Cartilage invasion, `<strong>VF fixation`</strong>, interarytenoid
 involvement, tongue base involvement, poor performance status
 </p>
 </li>
@@ -519,7 +519,7 @@ Supraglottic: yes for T1 N0
 </li>
 </ul>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/head-and-neck-surgery/staging-8th-edition.md
+++ b/head-and-neck-surgery/staging-8th-edition.md
@@ -4,7 +4,7 @@ title: Head &amp; Neck Staging - 8th Edition
 ---
 <h2 class="unnumbered" id="head-neck-staging---8th-edition">
 Head &
-Neck Staging - 8`<sup>`{=html}th`</sup>`{=html} Edition
+Neck Staging - 8`<sup>th`</sup> Edition
 </h2>
 <ul>
 <li>
@@ -70,21 +70,21 @@ N1
 </p>
 </td>
 <td>
-`<strong>`{=html}Single`</strong>`{=html} ipsilateral, \<3cm,
-ENE`<sub>`{=html}negative`</sub>`{=html}
+`<strong>Single`</strong> ipsilateral, \<3cm,
+ENE`<sub>negative`</sub>
 </td>
 <td>
 N2
 </td>
 <td>
 <p>
-N2`<sub>`{=html}ALL`</sub>`{=html}: \<6cm, ENE`<sub>`{=html}negative`</sub>`{=html}
+N2`<sub>ALL`</sub>: \<6cm, ENE`<sub>negative`</sub>
 </p>
 <p>
 N2a: single, ipsilateral
 </p>
 <p>
-N2b: `<strong>`{=html}multiple,`</strong>`{=html} ipsilateral
+N2b: `<strong>multiple,`</strong> ipsilateral
 </p>
 <p>
 N2c: bilateral/contralateral
@@ -98,7 +98,7 @@ N3
 N3a: \>6cm
 </p>
 <p>
-N3b: ENE`<sub>`{=html}positive`</sub>`{=html}
+N3b: ENE`<sub>positive`</sub>
 </p>
 </td>
 <li>
@@ -112,7 +112,7 @@ For Nasopharyngeal and P16 positive
 HPV Positive
 </th>
 <td>
-ipsilateral `<strong>`{=html}\<6cm`</strong>`{=html}
+ipsilateral `<strong>\<6cm`</strong>
 </td>
 <td>
 Contralateral/bilateral \<6cm
@@ -251,17 +251,17 @@ Skull base
 Carotid
 </p>
 <p>
-\*note similarities to T4b of p16`<sub>`{=html}neg`</sub>`{=html} OPC
+\*note similarities to T4b of p16`<sub>neg`</sub> OPC
 </p>
 </td>
 <p>
-`<img alt="" src="../media/image31.emf" style="width:1.79653in;height:1.52526in"/>`{=html} 
+`<img alt="" src="../media/image31.emf" style="width:1.79653in;height:1.52526in"/> 
 </p>
 <h3 class="unnumbered" id="oropharyngeal">
 OROPHARYNGEAL
 </h3>
 <p>
-`<strong>`{=html}HPV Neg (p16-) and HPV Pos`</strong>`{=html}
+`<strong>HPV Neg (p16-) and HPV Pos`</strong>
 </p>
 <col style="width: 16%"/>
 <col style="width: 43%"/>
@@ -324,10 +324,10 @@ Mandible
 </ul>
 <td>
 <p>
-`<strong>`{=html}T4a`</strong>`{=html} - Same
+`<strong>T4a`</strong> - Same
 </p>
 <p>
-`<strong>`{=html}T4b`</strong>`{=html} - Invades
+`<strong>T4b`</strong> - Invades
 </p>
 <ul>
 <li>
@@ -361,8 +361,8 @@ Clinical N staging
 <col style="width: 38%"/>
 <col style="width: 42%"/>
 <p>
-`<strong>`{=html}Note: ECE`</strong>`{=html} automatically `<strong>`{=html}bumps you up a N
-stage in the `<u>`{=html}pathological N grading system`</u>`{=html}`</strong>`{=html} (not
+`<strong>Note: ECE`</strong> automatically `<strong>bumps you up a N
+stage in the `<u>pathological N grading system`</u>`</strong> (not
 shown).
 </p>
 <p>
@@ -520,7 +520,7 @@ Mediastinum
 </li>
 </ul>
 <p>
-`<img alt="" src="../media/image32.png" style="width:1.85124in;height:1.97204in"/>`{=html} 
+`<img alt="" src="../media/image32.png" style="width:1.85124in;height:1.97204in"/> 
 </p>
 <p>
 In general, for Laryngeal Cancer
@@ -656,7 +656,7 @@ Cannot extend to esophageus or cause VF fixation
 </p>
 </td>
 <td>
-\>4cm OR invades `<strong>`{=html}esophageus`</strong>`{=html} OR causes VF
+\>4cm OR invades `<strong>esophageus`</strong> OR causes VF
 fixation
 </td>
 <ul>
@@ -778,14 +778,14 @@ Nasopharynx
  NASOPHARYNGEAL CA
 </h3>
 <p>
-`<strong>`{=html}WHO Type I`</strong>`{=html} - Keratinizing SCCA
+`<strong>WHO Type I`</strong> - Keratinizing SCCA
 </p>
 <p>
-`<strong>`{=html}WHO Type II`</strong>`{=html} - Nonkerating SCCA (associated with EBV,
+`<strong>WHO Type II`</strong> - Nonkerating SCCA (associated with EBV,
 better prognosis)
 </p>
 <p>
-`<strong>`{=html}WHO Type III`</strong>`{=html} - Undifferentiated CA
+`<strong>WHO Type III`</strong> - Undifferentiated CA
 </p>
 <td>
 Nasopharynx/nasal cavity
@@ -922,7 +922,7 @@ T4b: invading into carotid/mediastinum/RLN
 Thyroid cancer staging
 </p>
 <p>
-`<strong>`{=html}Only `<u>`{=html}\>55 years old`</u>`{=html}`</strong>`{=html}: those \<55yo are
+`<strong>Only `<u>\>55 years old`</u>`</strong>: those \<55yo are
 Stage I unless they have mets, then they are stage II
 </p>
 <p>
@@ -938,34 +938,34 @@ etc)
 <col style="width: 22%"/>
 <col style="width: 77%"/>
 <th>
- `<em>`{=html}T category`</em>`{=html}
+ `<em>T category`</em>
 </th>
 <td>
-`<em>`{=html}T1`</em>`{=html}
+`<em>T1`</em>
 </td>
 <td>
 \<2cm
 </td>
 <td>
-`<em>`{=html}T2`</em>`{=html}
+`<em>T2`</em>
 </td>
 <td>
 <p>
 2-4cm
 </p>
 <td>
-`<em>`{=html}T3`</em>`{=html}
+`<em>T3`</em>
 </td>
 <td>
-\>4cm or `<strong>`{=html}DOI \>6mm`</strong>`{=html} or Perineural/minor bone
+\>4cm or `<strong>DOI \>6mm`</strong> or Perineural/minor bone
 invasion
 </td>
 <td>
 <p>
-`<em>`{=html}T4a`</em>`{=html}
+`<em>T4a`</em>
 </p>
 <p>
-`<em>`{=html}T4b`</em>`{=html}
+`<em>T4b`</em>
 </p>
 </td>
 <td>
@@ -983,10 +983,10 @@ Tumor with skull base/foramina invasion
  MELANOMA (SKIN)
 </h3>
 <p>
- `<strong>`{=html}a/b/c classification`</strong>`{=html}
+ `<strong>a/b/c classification`</strong>
 </p>
 <p>
-T stage: IF `<strong>`{=html}ulceration`</strong>`{=html} stage is `<strong>`{=html}B`</strong>`{=html}
+T stage: IF `<strong>ulceration`</strong> stage is `<strong>B`</strong>
 (as in T2-\>T2b)
 </p>
 <p>
@@ -1034,7 +1034,7 @@ N stage
             </p>
             </td>
             <td>
-            `<strong>`{=html}N1`</strong>`{=html}
+            `<strong>N1`</strong>
             </td>
             <td>
             1 node
@@ -1044,7 +1044,7 @@ N stage
             1-2mm thick
             </p>
             <td>
-            `<strong>`{=html}N2`</strong>`{=html}
+            `<strong>N2`</strong>
             </td>
             <td>
             2-3 nodes
@@ -1053,7 +1053,7 @@ N stage
             2-4mm thick
             </td>
             <td>
-            `<strong>`{=html}N3`</strong>`{=html}
+            `<strong>N3`</strong>
             </td>
             <td>
             4+ nodes, matted nodes, or in transit mets
@@ -1087,7 +1087,7 @@ N stage
             </p>
             </td>
             <td>
-            `<strong>`{=html}M1`</strong>`{=html}
+            `<strong>M1`</strong>
             </td>
             <td>
             Any mets
@@ -1097,10 +1097,10 @@ N stage
             prevertebral space
             </td>
             <p>
-            `<img alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " src="../media/image33.png" style="width:1.88969in;height:2.90093in"/>`{=html}
+            `<img alt="MELANOMA STAGING DEPTH OF NUMBER OF 2 4 INVASION (MM) LYMPH NODES 0.8 - (in-transit m ets = N3) T staging (a) No ulceration (b) ulceration N staging (a) Micromets (&lt;0.1 mm) (b) Macromets (c) In-transit / satellite lesions w/o mets " src="../media/image33.png" style="width:1.88969in;height:2.90093in"/>
             </p>
             <p>
-            `<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+            `<a href="../index.html">Back to homepage`</a>
             </p>
             </td>
             </td>

--- a/index.md
+++ b/index.md
@@ -8,53 +8,53 @@ title: ENT Guidebook
 
 <ul>
 <li>
-`<a href="rules-of-the-game.html">`{=html}Rules of the Game`</a>`{=html}
+`<a href="rules-of-the-game.html">Rules of the Game`</a>
 </li>
 <li>
-`<a href="daily-routine.html">`{=html}Daily Routine`</a>`{=html}
+`<a href="daily-routine.html">Daily Routine`</a>
 </li>
 <li>
-`<a href="weekly-routines.html">`{=html}Weekly Routines`</a>`{=html}
+`<a href="weekly-routines.html">Weekly Routines`</a>
 </li>
 <li>
-`<a href="monthly-routines.html">`{=html}Monthly Routines`</a>`{=html}
+`<a href="monthly-routines.html">Monthly Routines`</a>
 </li>
 <li>
-`<a href="yearly-routines.html">`{=html}Yearly Routines`</a>`{=html}
+`<a href="yearly-routines.html">Yearly Routines`</a>
 </li>
 <li>
-`<a href="tips.html">`{=html}Tips`</a>`{=html}
+`<a href="tips.html">Tips`</a>
 </li>
 <li>
-`<a href="templates-protocols.html">`{=html}Templates/Protocols`</a>`{=html}
+`<a href="templates-protocols.html">Templates/Protocols`</a>
 </li>
 <li>
-`<a href="orders-discharges-and-dictations.html">`{=html}Orders, Discharges, and Dictations`</a>`{=html}
+`<a href="orders-discharges-and-dictations.html">Orders, Discharges, and Dictations`</a>
 </li>
 <li>
-`<a href="orientation/case-duty-hour-logs.html">`{=html}Case & Duty Hour Logs`</a>`{=html}
+`<a href="orientation/case-duty-hour-logs.html">Case & Duty Hour Logs`</a>
 </li>
 <li>
-`<a href="orientation/on-call-room.html">`{=html}On-Call Room`</a>`{=html}
+`<a href="orientation/on-call-room.html">On-Call Room`</a>
 </li>
 <li>
-`<a href="otolaryngology-national-conference-schedule.html">`{=html}Otolaryngology National Conference Schedule`</a>`{=html}
+`<a href="otolaryngology-national-conference-schedule.html">Otolaryngology National Conference Schedule`</a>
 </li>
 <li>
-`<a href="orientation/vacation-requests.html">`{=html}Vacation Requests`</a>`{=html}
+`<a href="orientation/vacation-requests.html">Vacation Requests`</a>
 </li>
 </ul>
 </li>
-\<h2`<a href="on-call/index.html">`{=html}On-Call`</a>`{=html}
+\<h2`<a href="on-call/index.html">On-Call`</a>
 <ul>
 <li>
-`<a href="on-call/calls.html">`{=html}Calls`</a>`{=html}
+`<a href="on-call/calls.html">Calls`</a>
 </li>
 <li>
-`<a href="on-call/consults.html">`{=html}Consults`</a>`{=html}
+`<a href="on-call/consults.html">Consults`</a>
 </li>
 <li>
-`<a href="facial-trauma-guide.html">`{=html}Facial Trauma Guide`</a>`{=html}
+`<a href="facial-trauma-guide.html">Facial Trauma Guide`</a>
 </li>
 </ul>
 </li>
@@ -64,65 +64,65 @@ Specialties
 </h2>
 <ul>
 <li>
-`<a href="otology/index.html">`{=html}Otology`</a>`{=html}
+`<a href="otology/index.html">Otology`</a>
 <ul>
 <li>
-`<a href="otology/clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="otology/clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="otology/neuro-otology-imaging.html">`{=html}Neuro-otology Imaging`</a>`{=html}
+`<a href="otology/neuro-otology-imaging.html">Neuro-otology Imaging`</a>
 </li>
 <li>
-`<a href="otology/otitis.html">`{=html}Otitis`</a>`{=html}
+`<a href="otology/otitis.html">Otitis`</a>
 </li>
 <li>
-`<a href="otology/or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="otology/or-guide.html">OR Guide`</a>
 </li>
 </ul>
 </li>
 <li>
-`<a href="facial-plastics.html">`{=html}Facial Plastics`</a>`{=html}
+`<a href="facial-plastics.html">Facial Plastics`</a>
 </li>
 <li>
-`<a href="pediatric-otolaryngology/index.html">`{=html}Pediatric Otolaryngology`</a>`{=html}
+`<a href="pediatric-otolaryngology/index.html">Pediatric Otolaryngology`</a>
 <ul>
 <li>
-`<a href="pediatric-otolaryngology/clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="pediatric-otolaryngology/clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="pediatric-otolaryngology/neck-masses.html">`{=html}Neck Masses`</a>`{=html}
+`<a href="pediatric-otolaryngology/neck-masses.html">Neck Masses`</a>
 </li>
 <li>
-`<a href="pediatric-otolaryngology/or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="pediatric-otolaryngology/or-guide.html">OR Guide`</a>
 </li>
 </ul>
 </li>
 <li>
-`<a href="rhinology.html">`{=html}Rhinology`</a>`{=html}
+`<a href="rhinology.html">Rhinology`</a>
 </li>
 <li>
-`<a href="laryngology.html">`{=html}Laryngology`</a>`{=html}
+`<a href="laryngology.html">Laryngology`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/index.html">`{=html}Head and Neck Surgery`</a>`{=html}
+`<a href="head-and-neck-surgery/index.html">Head and Neck Surgery`</a>
 <ul>
 <li>
-`<a href="head-and-neck-surgery/clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="head-and-neck-surgery/clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/squamous-cell-carcinoma.html">`{=html}Squamous Cell Carcinoma`</a>`{=html}
+`<a href="head-and-neck-surgery/squamous-cell-carcinoma.html">Squamous Cell Carcinoma`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/follow-up-guide.html">`{=html}Post-H&N Cancer Follow-up Guide`</a>`{=html}
+`<a href="head-and-neck-surgery/follow-up-guide.html">Post-H&N Cancer Follow-up Guide`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="head-and-neck-surgery/or-guide.html">OR Guide`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/post-op-guide.html">`{=html}Post-op Guide`</a>`{=html}
+`<a href="head-and-neck-surgery/post-op-guide.html">Post-op Guide`</a>
 </li>
 <li>
-`<a href="head-and-neck-surgery/staging-8th-edition.html">`{=html}Staging - 8th Edition`</a>`{=html}
+`<a href="head-and-neck-surgery/staging-8th-edition.html">Staging - 8th Edition`</a>
 </li>
 </ul>
 </li>
@@ -132,37 +132,37 @@ Specialties
 Resources
 <ul>
 <li>
-`<a href="perioperative-aspirin-anticoagulation-guide.html">`{=html}Perioperative Aspirin/Anticoagulation Guide`</a>`{=html}
+`<a href="perioperative-aspirin-anticoagulation-guide.html">Perioperative Aspirin/Anticoagulation Guide`</a>
 </li>
 <li>
-`<a href="rotations.html">`{=html}Rotations`</a>`{=html}
+`<a href="rotations.html">Rotations`</a>
 </li>
 <li>
-`<a href="antibiogram.html">`{=html}Antibiogram`</a>`{=html}
+`<a href="antibiogram.html">Antibiogram`</a>
 </li>
 <li>
-`<a href="medications.html">`{=html}Medication Dosing`</a>`{=html}
+`<a href="medications.html">Medication Dosing`</a>
 </li>
 <li>
-`<a href="local-rotational-flaps.html">`{=html}Local Rotational Flaps`</a>`{=html}
+`<a href="local-rotational-flaps.html">Local Rotational Flaps`</a>
 </li>
 <li>
-`<a href="levels-of-the-neck.html">`{=html}Levels of the Neck`</a>`{=html}
+`<a href="levels-of-the-neck.html">Levels of the Neck`</a>
 </li>
 <li>
-`<a href="radiology-levels-of-the-neck.html">`{=html}Radiology - Levels of the Neck`</a>`{=html}
+`<a href="radiology-levels-of-the-neck.html">Radiology - Levels of the Neck`</a>
 </li>
 <li>
-`<a href="or-instruments.html">`{=html}OR Instruments`</a>`{=html}
+`<a href="or-instruments.html">OR Instruments`</a>
 </li>
 <li>
-`<a href="cranial-nerves.html">`{=html}Cranial Nerves`</a>`{=html}
+`<a href="cranial-nerves.html">Cranial Nerves`</a>
 </li>
 <li>
-`<a href="review-of-systems.html">`{=html}Review of Systems`</a>`{=html}
+`<a href="review-of-systems.html">Review of Systems`</a>
 </li>
 <li>
-`<a href="map-of-tufts-medical-center.html">`{=html}Map of Tufts Medical Center`</a>`{=html}
+`<a href="map-of-tufts-medical-center.html">Map of Tufts Medical Center`</a>
 </li>
 </ul>
 </li>

--- a/laryngology.md
+++ b/laryngology.md
@@ -3,7 +3,7 @@ layout: default
 title: Laryngology
 ---
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>
 <!-- BEGIN Laryngology section imported from pocket guide -->
 <h2 id="laryngology">

--- a/levels-of-the-neck.md
+++ b/levels-of-the-neck.md
@@ -7,27 +7,27 @@ The neck is divided into lymph node levels that help describe disease extent and
 </p>
 <ol>
 <li>
-`<strong>`{=html}Level I`</strong>`{=html} -- submental and submandibular nodes bordered by the digastric muscles and mandible.
+`<strong>Level I`</strong> -- submental and submandibular nodes bordered by the digastric muscles and mandible.
 </li>
 <li>
-`<strong>`{=html}Level II`</strong>`{=html} -- upper jugular nodes from the skull base to the hyoid bone, anterior to the sternocleidomastoid.
+`<strong>Level II`</strong> -- upper jugular nodes from the skull base to the hyoid bone, anterior to the sternocleidomastoid.
 </li>
 <li>
-`<strong>`{=html}Level III`</strong>`{=html} -- middle jugular nodes between the hyoid and cricoid cartilage.
+`<strong>Level III`</strong> -- middle jugular nodes between the hyoid and cricoid cartilage.
 </li>
 <li>
-`<strong>`{=html}Level IV`</strong>`{=html} -- lower jugular nodes from the cricoid cartilage to the clavicle.
+`<strong>Level IV`</strong> -- lower jugular nodes from the cricoid cartilage to the clavicle.
 </li>
 <li>
-`<strong>`{=html}Level V`</strong>`{=html} -- nodes of the posterior triangle along the spinal accessory nerve.
+`<strong>Level V`</strong> -- nodes of the posterior triangle along the spinal accessory nerve.
 </li>
 <li>
-`<strong>`{=html}Level VI`</strong>`{=html} -- anterior compartment nodes surrounding the larynx and trachea.
+`<strong>Level VI`</strong> -- anterior compartment nodes surrounding the larynx and trachea.
 </li>
 </ol>
 <p>
 Understanding these levels is essential for staging head and neck cancers.
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/local-rotational-flaps.md
+++ b/local-rotational-flaps.md
@@ -7,13 +7,13 @@ Local rotational flaps allow closure of facial defects with tissue that matches 
 </p>
 <ul>
 <li>
-`<strong>`{=html}Ear`</strong>`{=html} -- concave helical rim defects repaired with a posterior auricular interpolation flap.
+`<strong>Ear`</strong> -- concave helical rim defects repaired with a posterior auricular interpolation flap.
 </li>
 <li>
-`<strong>`{=html}Lip`</strong>`{=html} -- lateral lip defects may be closed with a rotation flap from adjacent tissue; avoid medial cheek recruitment to preserve the melolabial crease.
+`<strong>Lip`</strong> -- lateral lip defects may be closed with a rotation flap from adjacent tissue; avoid medial cheek recruitment to preserve the melolabial crease.
 </li>
 <li>
-`<strong>`{=html}Nose`</strong>`{=html}
+`<strong>Nose`</strong>
 <ul>
 <li>
 Anterior alar groove: island pedicle flap.
@@ -30,5 +30,5 @@ Nasal tip or dorsum/sidewall: bilobed flap for 1--1.5 cm defects.
 For complex reconstruction, consult a facial plastics reference for flap design and planning.
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/map-of-tufts-medical-center.md
+++ b/map-of-tufts-medical-center.md
@@ -691,5 +691,5 @@ Interpreter (code 1031)
       </tr>
       </table>
       <p>
-      `<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+      `<a href="index.html">Back to homepage`</a>
       </p>

--- a/medications.md
+++ b/medications.md
@@ -124,5 +124,5 @@ Zofran IV 0.1mg/kg/dose q8hrs (max dose 4mg).
 </li>
 </ul>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/monthly-routines.md
+++ b/monthly-routines.md
@@ -4,21 +4,21 @@ title: Monthly Routines
 ---
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
 `<b style="mso-bidi-font-weight:
-normal">`{=html}Trauma Conference`</b>`{=html}: first Thursday of the month every other month
+normal">Trauma Conference`</b>: first Thursday of the month every other month
 (odd numbered months). Cases presented by the PGY-2 on-service during the
 trauma month. Location typically is the OMFS conference room
 </p>
-normal"\>`</b>`{=html}
+normal"\>`</b>
 </p>
-normal"\>Grand Rounds:`</b>`{=html} [ ]{style="mso-spacerun:yes"}Typically,
+normal"\>Grand Rounds:`</b> [ ]{style="mso-spacerun:yes"}Typically,
 monthly from Oct-Jun. Each resident PGY-2→PGY-5 presents an hour-long talk.
 Must have a faulty advisor.
 </p>
-normal"\>Morbidity & Mortality (M&M):`</b>`{=html} Four M&Ms over the year.
+normal"\>Morbidity & Mortality (M&M):`</b> Four M&Ms over the year.
 Oct, Jan, Apr, June.
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
 </p>
 <p>
-`<a href='index.html'>`{=html}Back to homepage`</a>`{=html}
+`<a href='index.html'>Back to homepage`</a>
 </p>

--- a/on-call-guide.md
+++ b/on-call-guide.md
@@ -12,11 +12,11 @@ Calls
 Post-tonsillectomy patients
 </h4>
 <p>
-· `<strong>`{=html}Bleeding:`</strong>`{=html} Ask all tonsil bleeds to go to an ED. If sounds like a large active bleed, they go
+· `<strong>Bleeding:`</strong> Ask all tonsil bleeds to go to an ED. If sounds like a large active bleed, they go
 to the nearest ED, otherwise they come to us.
 </p>
 <p>
-· `<strong>`{=html}Fever:`</strong>`{=html} Fever is expected for up to 2 weeks. If fever continues, can consider course of
+· `<strong>Fever:`</strong> Fever is expected for up to 2 weeks. If fever continues, can consider course of
 azithromycin (sometimes adenoid bed can become infected)
 </p>
 <p>
@@ -120,7 +120,7 @@ A Tonsillectomies: 2 weeks
 Post-Op Precautions:
 </h4>
 <p>
-· `<strong>`{=html}Dry ear precautions:`</strong>`{=html}
+· `<strong>Dry ear precautions:`</strong>
 </p>
 <p>
 A Before showering, coat a small piece of cotton with a tablespoon of Vaseline ointment. Gently
@@ -131,7 +131,7 @@ B If swimming or bathing is desired, purchase earplugs and a headband to keep ea
 out.
 </p>
 <p>
-· `<strong>`{=html}Sinus Precautions`</strong>`{=html} :
+· `<strong>Sinus Precautions`</strong> :
 </p>
 <p>
 A Blowing your nose: Do not pinch your nose: do not blow your nose. You can gently wipe your nose
@@ -197,8 +197,8 @@ monitoring and telemetry (its arrhythmia you are monitoring for)
 · It's never coming from both sides. If the ED has packed both sides, take at least one of them
 <p>
 · ED doctors can pack a nose. As an Otolaryngologist, when you see an epistaxis patient, your job
-is to find out where the bleeding is coming from and why it is happening. `<strong>`{=html}Find the bleeding
-source`</strong>`{=html}
+is to find out where the bleeding is coming from and why it is happening. `<strong>Find the bleeding
+source`</strong>
 </p>
 <p>
 · Soak the lidocaine/phenylephrine neuropatty and using bayonet forceps, gently feed it along the
@@ -210,28 +210,28 @@ by bit so that they are wiping the septum just before you visualize it. This wil
 bleeding is coming from.
 </p>
 <p>
-· `<strong>`{=html}If its anterior`</strong>`{=html} and a vessel can be seen, use a silver nitrate stick to cauterize it. Make
+· `<strong>If its anterior`</strong> and a vessel can be seen, use a silver nitrate stick to cauterize it. Make
 sure you dry the area before and after cautery with a cotton tip applicator otherwise it will drop
 down onto patients' lips and discolor their skin.
 </p>
 <p>
-· `<strong>`{=html}If its further back (mid septum)`</strong>`{=html} , wrap surgicel around Surgifoam (add some Bactroban) and
+· `<strong>If its further back (mid septum)`</strong> , wrap surgicel around Surgifoam (add some Bactroban) and
 press it against the area that's bleeding.
 </p>
 <p>
-· `<strong>`{=html}If it's posterior: use a posterior pack`</strong>`{=html}. Pumping vessels posteriorly will likely need to the
+· `<strong>If it's posterior: use a posterior pack`</strong>. Pumping vessels posteriorly will likely need to the
 OR to stop. Try medializing the middle turbinate and looking for the vessel on the lateral posterior
 aspect of the middle turbinate where the SPA comes out.
 </p>
 <p>
-· `<strong>`{=html}If it's an HHT patient`</strong>`{=html}. Surgiflo seems to work best. Just coat the entire nasal cavity with
+· `<strong>If it's an HHT patient`</strong>. Surgiflo seems to work best. Just coat the entire nasal cavity with
 it.
 </p>
 <h4>
 PTAs
 </h4>
 <p>
-· CBC w/ Diff; Rapid Strep; `<em>`{=html}Monospot`</em>`{=html}
+· CBC w/ Diff; Rapid Strep; `<em>Monospot`</em>
 </p>
 <p>
 · Decadron 10 mg IV x 1 (only if drained or neg needle aspiration + neg CT for abscess;
@@ -273,7 +273,7 @@ before - see anticoagulation guide
 higher risk of dislodging) duration, traumatic? Tube size? Extubation attempts, exposure)
 </p>
 <p>
-· `<strong>`{=html}Operative Steps:`</strong>`{=html} Place shoulder roll. mark out midline, hyoid, thyroid cartilage, cricoid,
+· `<strong>Operative Steps:`</strong> Place shoulder roll. mark out midline, hyoid, thyroid cartilage, cricoid,
 sternal notch. Match a 3-4cm incision between cricoid and sternal notch. Inject w/ lido w/ epi. Prep
 & drape. Incision w/ 15 blade through platysma. Use bipolar to stop skin bleeders. Use sennas on
 superior and inferior aspects of incision and pull up. Everything that comes up is safe. Push down
@@ -386,17 +386,17 @@ uro-jet (viscous lidocaine) to numb the posterior oropharynx
 Orbital Cellulitis
 </h4>
 <p>
-· `<strong>`{=html}Preseptal`</strong>`{=html}`<strong>`{=html}vs Orbital Cellulitis`</strong>`{=html} :
+· `<strong>Preseptal`</strong>`<strong>vs Orbital Cellulitis`</strong> :
 </p>
 <p>
-A Orbital cellulitis is likely to have `<strong>`{=html}chemosis`</strong>`{=html} , pain with EOMI, restricted eye movement
+A Orbital cellulitis is likely to have `<strong>chemosis`</strong> , pain with EOMI, restricted eye movement
 </p>
 <p>
-· `<strong>`{=html}When to drain a subperiosteal abscess?`</strong>`{=html} If the abscess volume is \<1250mm3 can avoid OR
+· `<strong>When to drain a subperiosteal abscess?`</strong> If the abscess volume is \<1250mm3 can avoid OR
 (measure abscess in 3 dimensions WxDxL in mm)
 </p>
 <p>
-· `<strong>`{=html}How to tell if there is a cavernous sinus thrombosis`</strong>`{=html} : get a MRI with contrast.
+· `<strong>How to tell if there is a cavernous sinus thrombosis`</strong> : get a MRI with contrast.
 </p>
 <p>
 A Look at DTI/DWI (isoDTI) - if the Cavernous sinus lights up, strong indication for Cavernous
@@ -421,24 +421,24 @@ vs neoplastic
 </p>
 <p>
 · Evaluate: O2 sat, respiratory rate, retractions, ability to lay supine. Stridor: insp:
-supraglottic/glottic. Biphasic: glottic/subglottic. Expiratory: trachea/bronchi. `<strong>`{=html}Perform
-fiberoptic exam and check airway`</strong>`{=html}
+supraglottic/glottic. Biphasic: glottic/subglottic. Expiratory: trachea/bronchi. `<strong>Perform
+fiberoptic exam and check airway`</strong>
 </p>
 <p>
-· Management`<strong>`{=html}:`</strong>`{=html}
+· Management`<strong>:`</strong>
 </p>
 <p>
-1 `<em>`{=html}Airway widely patent and mild edema, slow progression of symptoms`</em>`{=html} → observation on floor w/ O2
+1 `<em>Airway widely patent and mild edema, slow progression of symptoms`</em> → observation on floor w/ O2
 monitoring
 </p>
 <p>
-2 `<em>`{=html}Airway patent but moderate edema (e.g. angioedema patients)`</em>`{=html} → observation in ICU
+2 `<em>Airway patent but moderate edema (e.g. angioedema patients)`</em> → observation in ICU
 </p>
 <p>
-3 `<em>`{=html}Unable to entire airway`</em>`{=html} → OR for awake fiberoptic intubation w/ possible awake trach
+3 `<em>Unable to entire airway`</em> → OR for awake fiberoptic intubation w/ possible awake trach
 </p>
 <p>
-4 `<em>`{=html}Unable to see any airway`</em>`{=html} → OR for awake trach
+4 `<em>Unable to see any airway`</em> → OR for awake trach
 </p>
 <p>
 B Surgical Airway patients
@@ -506,32 +506,32 @@ Admissions from ED -- What service?
 In general, we have adopted the same model as Orthopedics.
 </p>
 <p>
-· `<strong>`{=html}Admit to Medicine with ENT consult`</strong>`{=html} : Adults with `<strong>`{=html}non-surgical issue`</strong>`{=html} (peritonsillar
-phlegmon, angioedema) or `<strong>`{=html}surgical issue + multiple co-morbidities`</strong>`{=html} (taking medications for T2DM
+· `<strong>Admit to Medicine with ENT consult`</strong> : Adults with `<strong>non-surgical issue`</strong> (peritonsillar
+phlegmon, angioedema) or `<strong>surgical issue + multiple co-morbidities`</strong> (taking medications for T2DM
 and HTN) or is high risk (history of MI)
 </p>
 <p>
-· `<strong>`{=html}Admit to ENT`</strong>`{=html} : Adults with non-complicated surgical patients (e.g.: retropharyngeal abscess)
+· `<strong>Admit to ENT`</strong> : Adults with non-complicated surgical patients (e.g.: retropharyngeal abscess)
 and those with post-op complications (unless it is purely medical e.g. poor PO intake, pain control
 etc.).
 </p>
 <p>
-· `<strong>`{=html}Admit to Pediatrics`</strong>`{=html} : Typically, all pediatric patients except those with post-surgical
+· `<strong>Admit to Pediatrics`</strong> : Typically, all pediatric patients except those with post-surgical
 complications go to Pediatrics
 </p>
 <p>
-`<strong>`{=html}General rule`</strong>`{=html} : Be reasonable. Medicine are reasonable...which means they tend to get dumped on a
+`<strong>General rule`</strong> : Be reasonable. Medicine are reasonable...which means they tend to get dumped on a
 lot. We should take the simple patients onto our service. At the same time, recognize that we are in
 the ORs during the day and are home-call at night so don't have the manpower to manage difficult
 patients.
 </p>
 <p>
-`<strong>`{=html}Inpatient or bedded outpatient patients who had surgery`</strong>`{=html} : they come to our service.
+`<strong>Inpatient or bedded outpatient patients who had surgery`</strong> : they come to our service.
 </p>
 <p>
-`<strong>`{=html}`<em>`{=html}`<br />`{=html}
-`</em>`{=html}`</strong>`{=html}
+`<strong>`<em>`<br />
+`</em>`</strong>
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/on-call/calls.md
+++ b/on-call/calls.md
@@ -11,14 +11,14 @@ Post-tonsillectomy patients
 <ul>
 <li>
 <p>
-`<strong>`{=html}Bleeding:`</strong>`{=html} Ask all tonsil bleeds to go to an ED.
+`<strong>Bleeding:`</strong> Ask all tonsil bleeds to go to an ED.
 If sounds like a large active bleed, they go to the nearest ED,
 otherwise they come to us.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Fever:`</strong>`{=html} Fever is expected for up to 2 weeks. If
+`<strong>Fever:`</strong> Fever is expected for up to 2 weeks. If
 fever continues, can consider course of azithromycin (sometimes adenoid
 bed can become infected)
 </p>
@@ -103,7 +103,7 @@ When can I fly? 2-3 weeks post-op
 </li>
 </ul>
 <p>
-`<strong>`{=html}Post-ear surgery Restrictions`</strong>`{=html}:
+`<strong>Post-ear surgery Restrictions`</strong>:
 </p>
 <ul>
 <li>
@@ -200,7 +200,7 @@ Precautions:
 <ul>
 <li>
 <p>
-`<strong>`{=html}Dry ear precautions:`</strong>`{=html}
+`<strong>Dry ear precautions:`</strong>
 </p>
 <ol type="A">
 <li>
@@ -220,7 +220,7 @@ headband to keep earplugs from falling out.
 </li>
 <li>
 <p>
-`<strong>`{=html}Sinus Precautions`</strong>`{=html}:
+`<strong>Sinus Precautions`</strong>:
 </p>
 <ol type="A">
 <li>

--- a/on-call/consults.md
+++ b/on-call/consults.md
@@ -81,8 +81,8 @@ sides, take at least one of them out.
 <p>
 ED doctors can pack a nose. As an Otolaryngologist, when you see
 an epistaxis patient, your job is to find out where the bleeding is
-coming from and why it is happening. `<strong>`{=html}Find the bleeding
-source`</strong>`{=html}
+coming from and why it is happening. `<strong>Find the bleeding
+source`</strong>
 </p>
 </li>
 <li>
@@ -101,7 +101,7 @@ from.
 </li>
 <li>
 <p>
-`<strong>`{=html}If its anterior`</strong>`{=html} and a vessel can be seen, use a
+`<strong>If its anterior`</strong> and a vessel can be seen, use a
 silver nitrate stick to cauterize it. Make sure you dry the area before
 and after cautery with a cotton tip applicator otherwise it will drop
 down onto patients' lips and discolor their skin.
@@ -109,14 +109,14 @@ down onto patients' lips and discolor their skin.
 </li>
 <li>
 <p>
-`<strong>`{=html}If its further back (mid septum)`</strong>`{=html}, wrap surgicel
+`<strong>If its further back (mid septum)`</strong>, wrap surgicel
 around Surgifoam (add some Bactroban) and press it against the area
 that's bleeding.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}If it's posterior: use a posterior pack`</strong>`{=html}. Pumping
+`<strong>If it's posterior: use a posterior pack`</strong>. Pumping
 vessels posteriorly will likely need to the OR to stop. Try medializing
 the middle turbinate and looking for the vessel on the lateral posterior
 aspect of the middle turbinate where the SPA comes out.
@@ -124,7 +124,7 @@ aspect of the middle turbinate where the SPA comes out.
 </li>
 <li>
 <p>
-`<strong>`{=html}If it's an HHT patient`</strong>`{=html}. Surgiflo seems to work
+`<strong>If it's an HHT patient`</strong>. Surgiflo seems to work
 best. Just coat the entire nasal cavity with it.
 </p>
 </li>
@@ -135,7 +135,7 @@ PTAs
 <ul>
 <li>
 <p>
-CBC w/ Diff; Rapid Strep; `<u>`{=html}Monospot`</u>`{=html}
+CBC w/ Diff; Rapid Strep; `<u>Monospot`</u>
 </p>
 </li>
 <li>
@@ -213,7 +213,7 @@ traumatic? Tube size? Extubation attempts, exposure)
 </li>
 <li>
 <p>
-`<strong>`{=html}Operative Steps:`</strong>`{=html} Place shoulder roll. mark out
+`<strong>Operative Steps:`</strong> Place shoulder roll. mark out
 midline, hyoid, thyroid cartilage, cricoid, sternal notch. Match a 3-4cm
 incision between cricoid and sternal notch. Inject w/ lido w/ epi. Prep
 & drape. Incision w/ 15 blade through platysma. Use bipolar to stop
@@ -227,11 +227,11 @@ under straps then can retract laterally first with senns then with army
 navy. If trach dives deep, comes from above thyroid over cricoid. Can
 also use bovie to separate thyroid. Careful with FiO2 and bovie coming
 up to the trachea. Switch to bipolar if you have to use it. Push fascia
-off trachea w/ a peanut. Expose you window (2/3`<sup>`{=html}rd`</sup>`{=html} tracheal
+off trachea w/ a peanut. Expose you window (2/3`<sup>rd`</sup> tracheal
 rings). Ask anesthesia to prepare circuit. Ask scrub tech to test cuff,
 put 10cc syringe on cuff of trach, put on obturator, get a 15 blade, ask
 anesthesia to lower cuff. Open trachea (careful not to cut cuff) by
-making two horizontal incisions over 2`<sup>`{=html}nd`</sup>`{=html} and 3`<sup>`{=html}rd`</sup>`{=html}
+making two horizontal incisions over 2`<sup>nd`</sup> and 3`<sup>rd`</sup>
 tracheal rings. Widen with curved mets. Use a pickup to hold piece of
 trachea between cuts and use heavy mayos to cut the sides of the
 incision to remove window. Widen w/ trach spreaders. Ask anesthesia to
@@ -409,26 +409,26 @@ Orbital Cellulitis
 <ul>
 <li>
 <p>
-`<strong>`{=html}Preseptal vs Orbital Cellulitis`</strong>`{=html}:
+`<strong>Preseptal vs Orbital Cellulitis`</strong>:
 </p>
 <ol type="A">
 <li>
-Orbital cellulitis is likely to have `<strong>`{=html}chemosis`</strong>`{=html}, pain
+Orbital cellulitis is likely to have `<strong>chemosis`</strong>, pain
 with EOMI, restricted eye movement
 </li>
 </ol>
 </li>
 <li>
 <p>
-`<strong>`{=html}When to drain a subperiosteal abscess?`</strong>`{=html} If the
-abscess volume is \<1250mm`<sup>`{=html}3`</sup>`{=html} can avoid OR (measure abscess
+`<strong>When to drain a subperiosteal abscess?`</strong> If the
+abscess volume is \<1250mm`<sup>3`</sup> can avoid OR (measure abscess
 in 3 dimensions WxDxL in
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}How to tell if there is a cavernous sinus
-thrombosis`</strong>`{=html}: get a MRI with contrast.
+`<strong>How to tell if there is a cavernous sinus
+thrombosis`</strong>: get a MRI with contrast.
 </p>
 <ol type="A">
 <li>
@@ -475,36 +475,36 @@ vs inflammatory vs foreign body vs neoplastic
 <p>
 Evaluate: O2 sat, respiratory rate, retractions, ability to lay
 supine. Stridor: insp: supraglottic/glottic. Biphasic:
-glottic/subglottic. Expiratory: trachea/bronchi. `<strong>`{=html}Perform
-fiberoptic exam and check airway`</strong>`{=html}
+glottic/subglottic. Expiratory: trachea/bronchi. `<strong>Perform
+fiberoptic exam and check airway`</strong>
 </p>
 </li>
 <li>
 <p>
-Management`<strong>`{=html}:`</strong>`{=html}
+Management`<strong>:`</strong>
 </p>
 <ol type="1">
 <li>
 <p>
-`<u>`{=html}Airway widely patent and mild edema, slow progression of
-symptoms`</u>`{=html} → observation on floor w/ O2 monitoring
+`<u>Airway widely patent and mild edema, slow progression of
+symptoms`</u> → observation on floor w/ O2 monitoring
 </p>
 </li>
 <li>
 <p>
-`<u>`{=html}Airway patent but moderate edema (e.g. angioedema
-patients)`</u>`{=html} → observation in ICU
+`<u>Airway patent but moderate edema (e.g. angioedema
+patients)`</u> → observation in ICU
 </p>
 </li>
 <li>
 <p>
-`<u>`{=html}Unable to entire airway`</u>`{=html} → OR for awake fiberoptic
+`<u>Unable to entire airway`</u> → OR for awake fiberoptic
 intubation w/ possible awake trach
 </p>
 </li>
 <li>
 <p>
-`<u>`{=html}Unable to see any airway`</u>`{=html} → OR for awake trach
+`<u>Unable to see any airway`</u> → OR for awake trach
 </p>
 </li>
 </ol>

--- a/on-call/index.md
+++ b/on-call/index.md
@@ -4,15 +4,15 @@ title: On-Call Resources
 ---
 <ul>
 <li>
-`<a href="../on-call-guide.html">`{=html}On-Call Guide`</a>`{=html}
+`<a href="../on-call-guide.html">On-Call Guide`</a>
 </li>
 <li>
-`<a href="calls.html">`{=html}Calls`</a>`{=html}
+`<a href="calls.html">Calls`</a>
 </li>
 <li>
-`<a href="consults.html">`{=html}Consults`</a>`{=html}
+`<a href="consults.html">Consults`</a>
 </li>
 <li>
-`<a href="../facial-trauma-guide.html">`{=html}Facial Trauma Guide`</a>`{=html}
+`<a href="../facial-trauma-guide.html">Facial Trauma Guide`</a>
 </li>
 </ul>

--- a/or-instruments.md
+++ b/or-instruments.md
@@ -41,7 +41,7 @@ Instruments
 </h3>
 <ul>
 <li>
-`<strong>`{=html}Otologic/Drills`</strong>`{=html}
+`<strong>Otologic/Drills`</strong>
 <ul>
 <li>
 Midas Rex and Vasio drill bits -- Pyxis outside OR 16
@@ -65,5 +65,5 @@ Baha drill -- Dr. Sillman's cart
 </li>
 </ul>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/orders-discharges-and-dictations.md
+++ b/orders-discharges-and-dictations.md
@@ -6,7 +6,7 @@ title: Orders, Discharges, and Dictations
 Orders, Discharges, & Dictations
 </h1>
 <p>
-`<strong>`{=html}Day surgery:`</strong>`{=html} On doctor order sheet, put any meds they need IN PACU on the left, then on the
+`<strong>Day surgery:`</strong> On doctor order sheet, put any meds they need IN PACU on the left, then on the
 right column write:
 </p>
 <ul>
@@ -29,7 +29,7 @@ Don't forget to fill out the brief operative note if you are not able to complet
 </li>
 </ul>
 <p>
-`<strong>`{=html}Inpatient/Bedded Outpatient Orders`</strong>`{=html}
+`<strong>Inpatient/Bedded Outpatient Orders`</strong>
 </p>
 <ul>
 <li>
@@ -43,7 +43,7 @@ Every patient needs orders for vital signs, I&Os, and a diet order
 </li>
 </ul>
 <p>
-`<strong>`{=html}Discharge Instructions (Generic)-`</strong>`{=html}
+`<strong>Discharge Instructions (Generic)-`</strong>
 </p>
 <ul>
 <li>
@@ -68,7 +68,7 @@ Call or return to the ED if you have fevers, chills, chest pain, difficulty brea
 </li>
 </ul>
 <p>
-`<strong>`{=html}Generic Operative Report Format:`</strong>`{=html}
+`<strong>Generic Operative Report Format:`</strong>
 </p>
 <ul>
 <li>
@@ -105,14 +105,14 @@ Findings
 Indications
 </li>
 <li>
-Description: Remember to explicitly note written `<strong>`{=html}consent`</strong>`{=html} , `<strong>`{=html}timeout`</strong>`{=html} , administration of `<strong>`{=html}antibiotics`</strong>`{=html} was performed, proper `<strong>`{=html}positioning`</strong>`{=html} and `<strong>`{=html}anesthesia`</strong>`{=html} were achieved, the area was `<strong>`{=html}prepped and drape in sterile fashion`</strong>`{=html} , `<strong>`{=html}sponge/needle/instrument counts were correct times two`</strong>`{=html} , and that the `<strong>`{=html}attending was scrubbed and present for the entirety of the case`</strong>`{=html}.
+Description: Remember to explicitly note written `<strong>consent`</strong> , `<strong>timeout`</strong> , administration of `<strong>antibiotics`</strong> was performed, proper `<strong>positioning`</strong> and `<strong>anesthesia`</strong> were achieved, the area was `<strong>prepped and drape in sterile fashion`</strong> , `<strong>sponge/needle/instrument counts were correct times two`</strong> , and that the `<strong>attending was scrubbed and present for the entirety of the case`</strong>.
 </li>
 <li>
-`<em>`{=html}For Dr. Scott's DLB's add plan`</em>`{=html}
+`<em>For Dr. Scott's DLB's add plan`</em>
 </li>
 </ul>
 <p>
-`<strong>`{=html}Example Dictation Description:`</strong>`{=html}
+`<strong>Example Dictation Description:`</strong>
 </p>
 <p>
 \*\* Begin: \*\*After informed consent was obtained, the patient was brought into the operating room and
@@ -122,18 +122,18 @@ injected with \_cc of 1% lidocaine with epinephrine. The patient was then preppe
 usual sterile fashion
 </p>
 <p>
-`<strong>`{=html}End:`</strong>`{=html} ...this concluded the procedure. The patient was turned over to the care of anesthesia and
+`<strong>End:`</strong> ...this concluded the procedure. The patient was turned over to the care of anesthesia and
 extubated without complication. The patient was then transported to the PACU in stable condition. Dr
 \_\_\_, the attending surgeon, was present throughout the entire case.
 </p>
 <p>
-`<strong>`{=html}`<em>`{=html} `</em>`{=html}`</strong>`{=html}
+`<strong>`<em> `</em>`</strong>
 </p>
 <h2>
 Case & Duty Hour Logs
 </h2>
 <p>
-`<strong>`{=html}`<em>`{=html}LOGGING DUTY HOURS`</em>`{=html}`</strong>`{=html}
+`<strong>`<em>LOGGING DUTY HOURS`</em>`</strong>
 </p>
 <ol>
 <li>
@@ -178,7 +178,7 @@ Vacation: use "log vacation" button, only log M-F
 </li>
 </ol>
 <p>
-`<strong>`{=html}`<em>`{=html}LOGGING CASES`</em>`{=html}`</strong>`{=html}
+`<strong>`<em>LOGGING CASES`</em>`</strong>
 </p>
 <ol>
 <li>
@@ -192,8 +192,8 @@ All residents must update cases monthly
 Located in the Resident Suites on Farnsworth 1st floor (you need to make sure your badge has access)
 </p>
 <p>
-`<strong>`{=html}Room A182 = ENT On Call Room`</strong>`{=html}`<strong>`{=html} Code=0044833`</strong>`{=html}
+`<strong>Room A182 = ENT On Call Room`</strong>`<strong> Code=0044833`</strong>
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/orientation/index.md
+++ b/orientation/index.md
@@ -4,39 +4,39 @@ title: Orientation
 ---
 <ul>
 <li>
-`<a href="../rules-of-the-game.html">`{=html}Rules of the Game`</a>`{=html}
+`<a href="../rules-of-the-game.html">Rules of the Game`</a>
 </li>
 <li>
-`<a href="../daily-routine.html">`{=html}Daily Routine`</a>`{=html}
+`<a href="../daily-routine.html">Daily Routine`</a>
 </li>
 <li>
-`<a href="../weekly-routines.html">`{=html}Weekly Routines`</a>`{=html}
+`<a href="../weekly-routines.html">Weekly Routines`</a>
 </li>
 <li>
-`<a href="../monthly-routines.html">`{=html}Monthly Routines`</a>`{=html}
+`<a href="../monthly-routines.html">Monthly Routines`</a>
 </li>
 <li>
-`<a href="../yearly-routines.html">`{=html}Yearly Routines`</a>`{=html}
+`<a href="../yearly-routines.html">Yearly Routines`</a>
 </li>
 <li>
-`<a href="../tips.html">`{=html}Tips`</a>`{=html}
+`<a href="../tips.html">Tips`</a>
 </li>
 <li>
-`<a href="../templates-protocols.html">`{=html}Templates/Protocols`</a>`{=html}
+`<a href="../templates-protocols.html">Templates/Protocols`</a>
 </li>
 <li>
-`<a href="../orders-discharges-and-dictations.html">`{=html}Orders, Discharges, and Dictations`</a>`{=html}
+`<a href="../orders-discharges-and-dictations.html">Orders, Discharges, and Dictations`</a>
 </li>
 <li>
-`<a href="case-duty-hour-logs.html">`{=html}Case & Duty Hour Logs`</a>`{=html}
+`<a href="case-duty-hour-logs.html">Case & Duty Hour Logs`</a>
 </li>
 <li>
-`<a href="on-call-room.html">`{=html}On-Call Room`</a>`{=html}
+`<a href="on-call-room.html">On-Call Room`</a>
 </li>
 <li>
-`<a href="../otolaryngology-national-conference-schedule.html">`{=html}Otolaryngology National Conference Schedule`</a>`{=html}
+`<a href="../otolaryngology-national-conference-schedule.html">Otolaryngology National Conference Schedule`</a>
 </li>
 <li>
-`<a href="vacation-requests.html">`{=html}Vacation Requests`</a>`{=html}
+`<a href="vacation-requests.html">Vacation Requests`</a>
 </li>
 </ul>

--- a/otolaryngology-national-conference-schedule.md
+++ b/otolaryngology-national-conference-schedule.md
@@ -127,7 +127,7 @@ Tufts: 3-month notice of vacations & conferences (NEOS, national) to Dr. Scott
 RIH: 2-month notice of vacations & conferences (NEOS, national) to Dr. Groblewski
 </li>
 <li>
-Brockton: way, way in notice of vacations & conferences (NEOS, national) to Lori Keany. `<strong>`{=html}Do not count on being off the weekend before/after a vacation`</strong>`{=html}
+Brockton: way, way in notice of vacations & conferences (NEOS, national) to Lori Keany. `<strong>Do not count on being off the weekend before/after a vacation`</strong>
 </li>
 <li>
 Children's: 2-month notice of vacations to Dr. Gi-Soo Lee and Alanna Boyson + the MEEI resident on service with you (who make the schedule)
@@ -149,5 +149,5 @@ October 1 -- January to March
 January 1 -- April to June
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/otology.md
+++ b/otology.md
@@ -39,7 +39,7 @@ Keep the plans short. Put a plan for each problem listed.
 <ul>
 <li>
 <p>
-`<img alt="" src="media/image3.png" style="width:1.16111in;height:1.14028in" />`{=html}including discussions regarding dry ear precautions. Put observation if no specific plan was proposed
+`<img alt="" src="media/image3.png" style="width:1.16111in;height:1.14028in" />including discussions regarding dry ear precautions. Put observation if no specific plan was proposed
 </p>
 </li>
 </ul>
@@ -61,28 +61,28 @@ Audiology
 <ul>
 <li>
 <p>
-`<strong>`{=html}PTA (pure tone)`</strong>`{=html}: Hearing sensitivity at 500,1000,2000Hz
+`<strong>PTA (pure tone)`</strong>: Hearing sensitivity at 500,1000,2000Hz
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}SRT`</strong>`{=html} - lowest threshold `<strong>`{=html}spondee`</strong>`{=html} can be repeated 50% of time
+`<strong>SRT`</strong> - lowest threshold `<strong>spondee`</strong> can be repeated 50% of time
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}WRS (word rec)`</strong>`{=html} - % correct of a 50 word list of `<u>`{=html}monosyllabic phonetically balanced words.`</u>`{=html} Given at 40dB greater than SRT
+`<strong>WRS (word rec)`</strong> - % correct of a 50 word list of `<u>monosyllabic phonetically balanced words.`</u> Given at 40dB greater than SRT
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Hearing loss levels:`</strong>`{=html} go down by 15dB starting at \<25dB
+`<strong>Hearing loss levels:`</strong> go down by 15dB starting at \<25dB
 </p>
 </li>
 </ul>
 <blockquote>
 <p>
-`<img alt="" src="media/image4.emf" style="width:1.65347in;height:1.54792in" />`{=html}`<strong>`{=html}Audiogram symbols`</strong>`{=html}: Right = O, Left = X (triangle for right masking, square for left masking → THINK ROLEX)
+`<img alt="" src="media/image4.emf" style="width:1.65347in;height:1.54792in" />`<strong>Audiogram symbols`</strong>: Right = O, Left = X (triangle for right masking, square for left masking → THINK ROLEX)
 </p>
 </blockquote>
 <h4 class="unnumbered" id="audiogram-patterns">
@@ -91,22 +91,22 @@ Audiogram Patterns
 <ol type="A">
 <li>
 <p>
-`<strong>`{=html}2kHz notch`</strong>`{=html} (air-bone) otosclerosis
+`<strong>2kHz notch`</strong> (air-bone) otosclerosis
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}4kHz notch`</strong>`{=html} (SNHL) - noise exposure
+`<strong>4kHz notch`</strong> (SNHL) - noise exposure
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Cookie bite`</strong>`{=html} -- hereditary
+`<strong>Cookie bite`</strong> -- hereditary
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Low Frequency`</strong>`{=html} (SNHL) --- Meniere's
+`<strong>Low Frequency`</strong> (SNHL) --- Meniere's
 </p>
 </li>
 </ol>
@@ -115,10 +115,10 @@ Tympanometry
 </h4>
 <blockquote>
 <p>
-`<strong>`{=html}Ad = `<u>`{=html}D`</u>`{=html}`</strong>`{=html}eep for `<strong>`{=html}`<u>`{=html}d`</u>`{=html}`</strong>`{=html}iscontinuity
+`<strong>Ad = `<u>D`</u>`</strong>eep for `<strong>`<u>d`</u>`</strong>iscontinuity
 </p>
 <p>
-As= `<strong>`{=html}`<u>`{=html}s`</u>`{=html}`</strong>`{=html}hallow for oto`<strong>`{=html}`<u>`{=html}s`</u>`{=html}`</strong>`{=html}clerosis /ossicular fixation
+As= `<strong>`<u>s`</u>`</strong>hallow for oto`<strong>`<u>s`</u>`</strong>clerosis /ossicular fixation
 </p>
 <p>
 B + volume wnl: OME
@@ -137,22 +137,22 @@ Acoustic Reflex Testing
 Image to the right are common patterns (Red = absent. Green = present)
 </p>
 <p>
-`<strong>`{=html}Right/Left`</strong>`{=html}: the side of the sound stimulus.
+`<strong>Right/Left`</strong>: the side of the sound stimulus.
 </p>
 <p>
-`<strong>`{=html}Ipsilateral/Contralateral`</strong>`{=html}: side that the reflect stimulus is detected.
+`<strong>Ipsilateral/Contralateral`</strong>: side that the reflect stimulus is detected.
 </p>
 <p>
-`<strong>`{=html}Note`</strong>`{=html}: Acoustic reflexes should be `<u>`{=html}absent`</u>`{=html} in `<u>`{=html}CHL`</u>`{=html} (otosclerosis etc) `<u>`{=html}unless`</u>`{=html} patients have `<u>`{=html}semicircular canal dehiscence.`</u>`{=html}
+`<strong>Note`</strong>: Acoustic reflexes should be `<u>absent`</u> in `<u>CHL`</u> (otosclerosis etc) `<u>unless`</u> patients have `<u>semicircular canal dehiscence.`</u>
 </p>
 <p>
-`<strong>`{=html}OAEs`</strong>`{=html}: `<u>`{=html}T`</u>`{=html}`<strong>`{=html}EOAE - newborn testing.`</strong>`{=html} `<u>`{=html}D`</u>`{=html}POAE - think `<u>`{=html}d`</u>`{=html}ouble tones (2 pure-tone freq.) DPOAE are good f or screening ototoxicity/noise toxicity
+`<strong>OAEs`</strong>: `<u>T`</u>`<strong>EOAE - newborn testing.`</strong> `<u>D`</u>POAE - think `<u>d`</u>ouble tones (2 pure-tone freq.) DPOAE are good f or screening ototoxicity/noise toxicity
 </p>
 <p>
-`<strong>`{=html}ECoG`</strong>`{=html}: Basically measuring Wave I on a ABR. The big thing to know is `<strong>`{=html}`<u>`{=html}\>0.45 SP/AP`</u>`{=html}`</strong>`{=html} is associated with `<strong>`{=html}`<u>`{=html}Meniere's`</u>`{=html}`</strong>`{=html}
+`<strong>ECoG`</strong>: Basically measuring Wave I on a ABR. The big thing to know is `<strong>`<u>\>0.45 SP/AP`</u>`</strong> is associated with `<strong>`<u>Meniere's`</u>`</strong>
 </p>
 <p>
-`<strong>`{=html}ABR`</strong>`{=html}: `<strong>`{=html}`<u>`{=html}Wave V latency`</u>`{=html}`</strong>`{=html} (\>0.2ms) due to retrocochlear pathology
+`<strong>ABR`</strong>: `<strong>`<u>Wave V latency`</u>`</strong> (\>0.2ms) due to retrocochlear pathology
 </p>
 <ol type="A">
 <li>
@@ -165,22 +165,22 @@ Abnormal wave I-V and III-V latency = CHL
 Neuro-otology Imaging
 </h2>
 <p>
-`<strong>`{=html}CT Temporal Bone`</strong>`{=html}:
+`<strong>CT Temporal Bone`</strong>:
 </p>
 <p>
-`<strong>`{=html}Stenvers/Perpendicular`</strong>`{=html} view: a long-axis projection of the petrous portion of the temporal bone, perpendicular to axis of cochlear (best for seeing cochlear implant electrode array) and is used to depict the `<strong>`{=html}round`</strong>`{=html} window, `<strong>`{=html}tegmen`</strong>`{=html}, as well as other structures.
+`<strong>Stenvers/Perpendicular`</strong> view: a long-axis projection of the petrous portion of the temporal bone, perpendicular to axis of cochlear (best for seeing cochlear implant electrode array) and is used to depict the `<strong>round`</strong> window, `<strong>tegmen`</strong>, as well as other structures.
 </p>
 <p>
-The `<strong>`{=html}Poschl/Parallel`</strong>`{=html} view, a short-axis view of the petrous pyramid, was used to optimally visualize the `<strong>`{=html}superior semicircular canal`</strong>`{=html}
+The `<strong>Poschl/Parallel`</strong> view, a short-axis view of the petrous pyramid, was used to optimally visualize the `<strong>superior semicircular canal`</strong>
 </p>
 <h4 class="unnumbered" id="how-to-read-temporal-bone-images">
 How to Read Temporal Bone Images
 </h4>
 <p>
-`<strong>`{=html}Divide into:`</strong>`{=html} EAC, Middle Ear, Inner Ear, Petrous Apex, Intratemporal Facial Nerve
+`<strong>Divide into:`</strong> EAC, Middle Ear, Inner Ear, Petrous Apex, Intratemporal Facial Nerve
 </p>
 <p>
-`<strong>`{=html}External Auditory Canal (EAC):`</strong>`{=html}
+`<strong>External Auditory Canal (EAC):`</strong>
 </p>
 <ul>
 <li>
@@ -215,7 +215,7 @@ Canal Atresia/Stenosis: look at ossicles -- malleus/incus are typically fused. O
 </li>
 </ul>
 <p>
-`<strong>`{=html}Middle Ear`</strong>`{=html}
+`<strong>Middle Ear`</strong>
 </p>
 <ul>
 <li>
@@ -235,7 +235,7 @@ Glomus Tympanicum: oval mass of cochlear promontory
 </li>
 </ul>
 <p>
-`<strong>`{=html}Inner Ear`</strong>`{=html}
+`<strong>Inner Ear`</strong>
 </p>
 <ul>
 <li>
@@ -272,7 +272,7 @@ Otosclerosis: demineralized bone over otic capsule
 </li>
 </ul>
 <p>
-`<strong>`{=html}Petrous Apex`</strong>`{=html}
+`<strong>Petrous Apex`</strong>
 </p>
 <ul>
 <li>
@@ -297,7 +297,7 @@ Chondrosarcoma: look for intratumoral calcification
 </li>
 </ul>
 <p>
-`<strong>`{=html}Intratemporal Fossa`</strong>`{=html}
+`<strong>Intratemporal Fossa`</strong>
 </p>
 <ul>
 <li>
@@ -317,10 +317,10 @@ Epidermoids: : T1 hypointense and T2 hyperintense, doesn't enhance. Differentiat
 </li>
 </ul>
 <p>
-`<img alt="" src="media/image5.png" style="width:3.75841in;height:3.04933in" />`{=html}
+`<img alt="" src="media/image5.png" style="width:3.75841in;height:3.04933in" />
 </p>
 <p>
-`<em>`{=html}Image:`</em>`{=html} Adunka and Buchman, `<em>`{=html}Otology, Neurotology, and Lateral Skull Base Surgery`</em>`{=html}
+`<em>Image:`</em> Adunka and Buchman, `<em>Otology, Neurotology, and Lateral Skull Base Surgery`</em>
 </p>
 <p>
 .
@@ -329,7 +329,7 @@ Epidermoids: : T1 hypointense and T2 hyperintense, doesn't enhance. Differentiat
 MRI Internal Auditory Canal
 </h4>
 <p>
-`<strong>`{=html}General principles of MRI:`</strong>`{=html}
+`<strong>General principles of MRI:`</strong>
 </p>
 <table>
 <colgroup>
@@ -832,7 +832,7 @@ Test cranial nerves
 </li>
 <li>
 <p>
-Nystagmus: `<strong>`{=html}nystagmus named in direction of fast phase`</strong>`{=html}
+Nystagmus: `<strong>nystagmus named in direction of fast phase`</strong>
 </p>
 <ol type="A">
 <li>
@@ -869,12 +869,12 @@ Check for BPPV:
 <ol type="A">
 <li>
 <p>
-`<strong>`{=html}Dix Hallpike`</strong>`{=html}: have head turned to one side then drop patient flat with head hanging slightly backwards. Repeat for both sides. Rotatory nystagmus occurs on the side of the lesion. Posterior SCC most common site
+`<strong>Dix Hallpike`</strong>: have head turned to one side then drop patient flat with head hanging slightly backwards. Repeat for both sides. Rotatory nystagmus occurs on the side of the lesion. Posterior SCC most common site
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Head-shake test:`</strong>`{=html}
+`<strong>Head-shake test:`</strong>
 </p>
 </li>
 </ol>
@@ -882,13 +882,13 @@ Check for BPPV:
 </ol>
 <blockquote>
 <p>
-Ask patient to close eyes then shake head (lateral rotation left and right) twice a second (2Hz) for 15-20 seconds. Ask them to open eyes. `<strong>`{=html}Fast phase = towards lesion`</strong>`{=html}
+Ask patient to close eyes then shake head (lateral rotation left and right) twice a second (2Hz) for 15-20 seconds. Ask them to open eyes. `<strong>Fast phase = towards lesion`</strong>
 </p>
 </blockquote>
 <ol start="3" type="A">
 <li>
 <p>
-`<strong>`{=html}Head Impulse test/Head Trust`</strong>`{=html}
+`<strong>Head Impulse test/Head Trust`</strong>
 </p>
 </li>
 </ol>
@@ -900,7 +900,7 @@ Hold head and quickly rotate it toward one ear while patient fixates on your nos
 <ol start="4" type="A">
 <li>
 <p>
-`<strong>`{=html}Oscillopsia test`</strong>`{=html}: a quick test to evaluate for bilateral vestibular loss: Have patient do a head shake test while reading a snellen chart. If visual acuity significantly different than at rest, suspect b/l vestibular dysfunction
+`<strong>Oscillopsia test`</strong>: a quick test to evaluate for bilateral vestibular loss: Have patient do a head shake test while reading a snellen chart. If visual acuity significantly different than at rest, suspect b/l vestibular dysfunction
 </p>
 </li>
 </ol>
@@ -908,7 +908,7 @@ Hold head and quickly rotate it toward one ear while patient fixates on your nos
 Additional testing
 </p>
 <p>
-`<img src="media/image6.png" style="width:1.65764in;height:0.925in" alt="Machine generated alternative text: Right Right beating nystagmus Fast beat Horizontal Slow beat Left beating nystagmus Left Slow beat Fast beat " />`{=html}`<strong>`{=html}VNG/ENG`</strong>`{=html}: If you have a nystagmus graph. Use ur arms to determine which side. Ur left arm can be parallel to left sided slow beating.
+`<img src="media/image6.png" style="width:1.65764in;height:0.925in" alt="Machine generated alternative text: Right Right beating nystagmus Fast beat Horizontal Slow beat Left beating nystagmus Left Slow beat Fast beat " />`<strong>VNG/ENG`</strong>: If you have a nystagmus graph. Use ur arms to determine which side. Ur left arm can be parallel to left sided slow beating.
 </p>
 <h4 class="unnumbered" id="caloric-testing">
 Caloric Testing
@@ -979,7 +979,7 @@ Phase lead - exaggerated in peripheral disease
 </li>
 </ul>
 <p>
-`<strong>`{=html}VEMP`</strong>`{=html} (cervical to SCM)
+`<strong>VEMP`</strong> (cervical to SCM)
 </p>
 <ul>
 <li>
@@ -994,17 +994,17 @@ oVEMP evaluates utricle (horizontal acceleration) -\> superior vestibular nerve
 </li>
 <li>
 <p>
-Unilateral decreased `<strong>`{=html}amplitude`</strong>`{=html} - peripheral lesion
+Unilateral decreased `<strong>amplitude`</strong> - peripheral lesion
 </p>
 </li>
 <li>
 <p>
-Decreased `<strong>`{=html}threshold`</strong>`{=html} - SCC dehiscence or perilymph fistula
+Decreased `<strong>threshold`</strong> - SCC dehiscence or perilymph fistula
 </p>
 </li>
 <li>
 <p>
-Increased `<strong>`{=html}threshold`</strong>`{=html} - middle ear pathology or ossicular chain abnormalities
+Increased `<strong>threshold`</strong> - middle ear pathology or ossicular chain abnormalities
 </p>
 </li>
 </ul>
@@ -1014,12 +1014,12 @@ Other
 <ol type="1">
 <li>
 <p>
-`<strong>`{=html}vHIT`</strong>`{=html}: basically a recorded head impulse test
+`<strong>vHIT`</strong>: basically a recorded head impulse test
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Computer Dynamic Posturography`</strong>`{=html}: expensive test to test proprioception
+`<strong>Computer Dynamic Posturography`</strong>: expensive test to test proprioception
 </p>
 </li>
 </ol>
@@ -1045,7 +1045,7 @@ Causes of Vertigo
 Perilymph Fistula
 </h4>
 <p>
--sudden `<u>`{=html}SNHL w/ vertigo`</u>`{=html} s/p trauma
+-sudden `<u>SNHL w/ vertigo`</u> s/p trauma
 </p>
 <p>
 -Tullio's phenomenon (vertigo w/ loud sound) Hennebert's sign: (vertigo w/ pneumatoscopy)
@@ -1060,7 +1060,7 @@ Superior Semicircular Canal Dehiscence
 -vertigo, autophony, Tullio's & Hennebert's sign, aural fullness
 </p>
 <p>
--Audiogram: CHL, supernormal bone conduction. cVEMP (↓threshold, ↑amplitude), `<strong>`{=html}acoustic reflexes are present`</strong>`{=html}
+-Audiogram: CHL, supernormal bone conduction. cVEMP (↓threshold, ↑amplitude), `<strong>acoustic reflexes are present`</strong>
 </p>
 <p>
 -CT Temporal Bone: Get Porshl's view
@@ -1078,16 +1078,16 @@ BPPV - Clinical Practice Guideline
 -Assess patient's home safety/risk of falling + ability to perform Epley
 </p>
 <p>
-\-`<strong>`{=html}No`</strong>`{=html} i`<strong>`{=html}maging or vestibular testing or vestibular suppressants`</strong>`{=html} for those who have symptoms+exam findings of BPPV
+\-`<strong>No`</strong> i`<strong>maging or vestibular testing or vestibular suppressants`</strong> for those who have symptoms+exam findings of BPPV
 </p>
 <p>
--Can offer observation, vestibular rehab, or Epley maneuver: Dix hall pike to the offending side. Wait for nystagmus to stop, rotate head to contralateral side. `<strong>`{=html}Hold head`</strong>`{=html} and ask patient to rotate onto stomach, then have them tuck heels to bum and sit up. `<strong>`{=html}Repeat`</strong>`{=html} until nystagmus is gone
+-Can offer observation, vestibular rehab, or Epley maneuver: Dix hall pike to the offending side. Wait for nystagmus to stop, rotate head to contralateral side. `<strong>Hold head`</strong> and ask patient to rotate onto stomach, then have them tuck heels to bum and sit up. `<strong>Repeat`</strong> until nystagmus is gone
 </p>
 <p>
 -can do Semont maneuver. Ask patient to keep head elevated for 48hours.
 </p>
 <p>
--patients w/ migraines and motion refractory take longer to recover. `<u>`{=html}F/u in 4-6 weeks`</u>`{=html}. If refractory, send to neurology to r/o migraines and get MRI to r/o retrocochlear pathology.
+-patients w/ migraines and motion refractory take longer to recover. `<u>F/u in 4-6 weeks`</u>. If refractory, send to neurology to r/o migraines and get MRI to r/o retrocochlear pathology.
 </p>
 <p>
 -surgery Tx: singular Neuroectomy (historic) posterior SCC occlusion (pack Posterior SCC with bone wax)
@@ -1105,13 +1105,13 @@ Dx: Audiogram & ECoG: SP/AP \>0.35
 Tx: restrict salt intake \<1.5g/day, avoid EtOH, caffeine, even out water consumption
 </p>
 <p>
-`<strong>`{=html}Acute Vertigo`</strong>`{=html} (diazepam 5-10mg q12hrs/lorazepam 0.5-1mg q6hrs + zofran 4mg q8hrs +/- Benadryl 25-50mg q4-6hrs)
+`<strong>Acute Vertigo`</strong> (diazepam 5-10mg q12hrs/lorazepam 0.5-1mg q6hrs + zofran 4mg q8hrs +/- Benadryl 25-50mg q4-6hrs)
 </p>
 <p>
-`<strong>`{=html}Maintenance therapy`</strong>`{=html}: HCTZ 50mg qdaily
+`<strong>Maintenance therapy`</strong>: HCTZ 50mg qdaily
 </p>
 <p>
-`<strong>`{=html}Surgery`</strong>`{=html}: endolymphatic sac decompression, transtympanic gentamycin injection (0.5 to 0.75 mL of a 40 mg/mL solution of gentamicin into middle ear space)
+`<strong>Surgery`</strong>: endolymphatic sac decompression, transtympanic gentamycin injection (0.5 to 0.75 mL of a 40 mg/mL solution of gentamicin into middle ear space)
 </p>
 <h4 class="unnumbered" id="other-causes-of-vertigo">
 Other causes of vertigo
@@ -1131,12 +1131,12 @@ Acute Otitis Externa -- Clinical Practice Guideline
 <ul>
 <li>
 <p>
-`<img alt="" src="media/image7.jpeg" style="width:0.88194in;height:0.86944in" />`{=html}`<strong>`{=html}Diagnosis`</strong>`{=html}: rapid onset (over 2 days) + ear pain, itchiness, fullness + EITHER signs of ear canal fullness (tenderness of tragus/pinnae) OR diffuse canal edema. Otorrhea is not needed for diagnosis. `<strong>`{=html}MCC`</strong>`{=html}: P aeruginosa + staph aureus. `<strong>`{=html}Eval for`</strong>`{=html}: Hx of T2DM, HIV, hx of XRT/immunocompromised. `<strong>`{=html}Check for`</strong>`{=html} TM perforation/Tubes -- ciprodex/ofloxacin are the only drops if perforation/tubes are present. `<u>`{=html}If cranial nerve palsy or granulation tissue on inferior aspect of canal (at bony-cartilaginous junction)`</u>`{=html}: consider malignant otitis externa (which is AOE + osteomyelitis of skull base)
+`<img alt="" src="media/image7.jpeg" style="width:0.88194in;height:0.86944in" />`<strong>Diagnosis`</strong>: rapid onset (over 2 days) + ear pain, itchiness, fullness + EITHER signs of ear canal fullness (tenderness of tragus/pinnae) OR diffuse canal edema. Otorrhea is not needed for diagnosis. `<strong>MCC`</strong>: P aeruginosa + staph aureus. `<strong>Eval for`</strong>: Hx of T2DM, HIV, hx of XRT/immunocompromised. `<strong>Check for`</strong> TM perforation/Tubes -- ciprodex/ofloxacin are the only drops if perforation/tubes are present. `<u>If cranial nerve palsy or granulation tissue on inferior aspect of canal (at bony-cartilaginous junction)`</u>: consider malignant otitis externa (which is AOE + osteomyelitis of skull base)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Tx`</strong>`{=html}: `<strong>`{=html}Topical Abx:`</strong>`{=html} Ciprodex/cipro HC, cortisporin, acetic acid (Vinegar), Vosol HC (acetic acid+hydrocortisone). Dosing should be at least BID, for 7-10days Don't give systemic antibiotics unless patients are high risk: T2DM, HIV, `<strong>`{=html}Tell patients how to apply otic drops`</strong>`{=html}: lie with affected ear up. Put drops. Tragus pump to help. Stay in position x3-5mins.
+`<strong>Tx`</strong>: `<strong>Topical Abx:`</strong> Ciprodex/cipro HC, cortisporin, acetic acid (Vinegar), Vosol HC (acetic acid+hydrocortisone). Dosing should be at least BID, for 7-10days Don't give systemic antibiotics unless patients are high risk: T2DM, HIV, `<strong>Tell patients how to apply otic drops`</strong>: lie with affected ear up. Put drops. Tragus pump to help. Stay in position x3-5mins.
 </p>
 </li>
 <li>
@@ -1146,7 +1146,7 @@ When to place ear wick: If EAC edema means TM cannot be seen
 </li>
 <li>
 <p>
-`<img alt="" src="media/image8.jpeg" style="width:1.27917in;height:1.01528in" />`{=html}Follow up should be in 2-3 days
+`<img alt="" src="media/image8.jpeg" style="width:1.27917in;height:1.01528in" />Follow up should be in 2-3 days
 </p>
 </li>
 </ul>
@@ -1175,19 +1175,19 @@ Chronic Otitis Externa
 -\>6weeks of persistent OE.
 </p>
 <p>
--first try `<strong>`{=html}mineral oil`</strong>`{=html} 2-3 drops at night. F/U in 2 months
+-first try `<strong>mineral oil`</strong> 2-3 drops at night. F/U in 2 months
 </p>
 <p>
--next can try `<strong>`{=html}DermOtic`</strong>`{=html} (fluocinolone) if that doesn't work
+-next can try `<strong>DermOtic`</strong> (fluocinolone) if that doesn't work
 </p>
 <h4 class="unnumbered" id="fungal-otitis-external-otomycosis">
 Fungal Otitis External (Otomycosis)
 </h4>
 <p>
-MCC: aspergillus. Exam shows sheets of keratin with black conidophores on top of white filamentous hyphae. Tx: acetic acid (vinegar) vs c`<strong>`{=html}lotrimazole 1% solution (lotrimin)`</strong>`{=html}, glucose control, dry ear precautions. Consider gentian violet or methyl-cresyl actate for refractors cases
+MCC: aspergillus. Exam shows sheets of keratin with black conidophores on top of white filamentous hyphae. Tx: acetic acid (vinegar) vs c`<strong>lotrimazole 1% solution (lotrimin)`</strong>, glucose control, dry ear precautions. Consider gentian violet or methyl-cresyl actate for refractors cases
 </p>
 <h3 class="unnumbered" id="tinnitus-clinical-practice-guideline">
-Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
+Tinnitus-`<strong>Clinical Practice Guideline`</strong>
 </h3>
 <p>
 
@@ -1197,7 +1197,7 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   -In general, don't get imaging. Only get imaging if tinnitus + either unilateral/asymmetric hearing loss or neurological abnormalities
   </p>
   <p>
-  -Tx: can observe for bothersome tinnitus that has lasted for \<6months. For tinnitus that is bothersome & persistent (\>6months) guideline recommends: `<strong>`{=html}sound therapy`</strong>`{=html} (white noise machine), `<strong>`{=html}cognitive behavior therapy`</strong>`{=html}, and `<strong>`{=html}hearing aids`</strong>`{=html} (ONLY IF patients have hearing loss). Guideline recommend against: dietary supplements, deep-brain stimulation, medical therapy. Dr Sillman also likely to recommend meditation.
+  -Tx: can observe for bothersome tinnitus that has lasted for \<6months. For tinnitus that is bothersome & persistent (\>6months) guideline recommends: `<strong>sound therapy`</strong> (white noise machine), `<strong>cognitive behavior therapy`</strong>, and `<strong>hearing aids`</strong> (ONLY IF patients have hearing loss). Guideline recommend against: dietary supplements, deep-brain stimulation, medical therapy. Dr Sillman also likely to recommend meditation.
   </p>
   <h3 class="unnumbered" id="otosclerosis">
   Otosclerosis
@@ -1205,12 +1205,12 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   <ul>
   <li>
   <p>
-  Ask: Progressive CHL beginning in 20-40yo. Strong family history (`<strong>`{=html}Autosomal Dominant w/ incomplete penetrance)`</strong>`{=html}. Often have tinnitus. Hear better in noise
+  Ask: Progressive CHL beginning in 20-40yo. Strong family history (`<strong>Autosomal Dominant w/ incomplete penetrance)`</strong>. Often have tinnitus. Hear better in noise
   </p>
   </li>
   <li>
   <p>
-  Exam: Schwartze sign (red hue behind TM). Audiogram: look for Carharts notch @ 2kHz (CO2: Carhart notch in Otosclerosis at 2Khz). Absent acoustic reflex. Shallow tympanometry (As: for Oto`<u>`{=html}s`</u>`{=html}clerosis)
+  Exam: Schwartze sign (red hue behind TM). Audiogram: look for Carharts notch @ 2kHz (CO2: Carhart notch in Otosclerosis at 2Khz). Absent acoustic reflex. Shallow tympanometry (As: for Oto`<u>s`</u>clerosis)
   </p>
   </li>
   <li>
@@ -1269,25 +1269,25 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Facial Nerve
   </h3>
   <p>
-  `<strong>`{=html}Intracranial segment`</strong>`{=html}: gives of Nervus intermedius -- contributes to GSPN and chorda tympani -\> `<strong>`{=html}meatal`</strong>`{=html}: through IAC to fundus -\> `<strong>`{=html}labyrinthine`</strong>`{=html}: shortest segment -- goes to geniculate ganglion and gives of GSPN \[gives off pregang. Parasymp to lacrimal gland\] -\> `<strong>`{=html}tympanic`</strong>`{=html} : goes inferior to HSCC & above oval window/stapes (which is why you down-fracture stapes) -\> mastoid segment
+  `<strong>Intracranial segment`</strong>: gives of Nervus intermedius -- contributes to GSPN and chorda tympani -\> `<strong>meatal`</strong>: through IAC to fundus -\> `<strong>labyrinthine`</strong>: shortest segment -- goes to geniculate ganglion and gives of GSPN \[gives off pregang. Parasymp to lacrimal gland\] -\> `<strong>tympanic`</strong> : goes inferior to HSCC & above oval window/stapes (which is why you down-fracture stapes) -\> mastoid segment
   </p>
   <p>
-  `<strong>`{=html}Management of FN paralysis`</strong>`{=html}:
+  `<strong>Management of FN paralysis`</strong>:
   </p>
   <ul>
   <li>
   <p>
-  `<strong>`{=html}HBI`</strong>`{=html}-`<strong>`{=html}V (Day 0-14)`</strong>`{=html}: Give 14 day course of prednisone and have them f/u within 1 week. If progressed to HBVI at f/u, get a ENoG,
+  `<strong>HBI`</strong>-`<strong>V (Day 0-14)`</strong>: Give 14 day course of prednisone and have them f/u within 1 week. If progressed to HBVI at f/u, get a ENoG,
   </p>
   </li>
   <li>
   <p>
-  `<strong>`{=html}HBVI (Day 0-3):`</strong>`{=html} Give 14 day course of prednisone, f/u within 1 week
+  `<strong>HBVI (Day 0-3):`</strong> Give 14 day course of prednisone, f/u within 1 week
   </p>
   </li>
   <li>
   <p>
-  `<strong>`{=html}HBVI (Day3-14)`</strong>`{=html}: Get ENoG. If \>90% degeneration: Get EMG: decompress nerve if EMG is negative, observe if positive. If \<90% degeneration: give Prednisone.
+  `<strong>HBVI (Day3-14)`</strong>: Get ENoG. If \>90% degeneration: Get EMG: decompress nerve if EMG is negative, observe if positive. If \<90% degeneration: give Prednisone.
   </p>
   </li>
   </ul>
@@ -1295,10 +1295,10 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Bell's Palsy -- Clinical Practice Guideline
   </h4>
   <p>
-  Dx: typically rapid onset unilateral FN paresis or paralysis. `<strong>`{=html}R/O stroke, parotid mass, systemic/infection`</strong>`{=html}. Ask about `<strong>`{=html}Sarcoidosis`</strong>`{=html} (Heerfordt fever). Guidelines say: `<strong>`{=html}no lab or imaging tests needed`</strong>`{=html}. If complete paralysis (HBVI) can `<em>`{=html}offer`</em>`{=html} ENoG/EMG (get after 7 days). If HBI→HBV: don't get nerve testing
+  Dx: typically rapid onset unilateral FN paresis or paralysis. `<strong>R/O stroke, parotid mass, systemic/infection`</strong>. Ask about `<strong>Sarcoidosis`</strong> (Heerfordt fever). Guidelines say: `<strong>no lab or imaging tests needed`</strong>. If complete paralysis (HBVI) can `<em>offer`</em> ENoG/EMG (get after 7 days). If HBI→HBV: don't get nerve testing
   </p>
   <p>
-  Tx: `<strong>`{=html}eye protection`</strong>`{=html}: tape eyes shut at night, eye drops + `<strong>`{=html}steroids within 72hrs of symptoms:`</strong>`{=html} at least 5 days of high dose then taper. Can add antivirals but meh evidence. `<strong>`{=html}f/u in 3 months`</strong>`{=html} sooner if ocular symptoms or new/worsening neurological symptoms
+  Tx: `<strong>eye protection`</strong>: tape eyes shut at night, eye drops + `<strong>steroids within 72hrs of symptoms:`</strong> at least 5 days of high dose then taper. Can add antivirals but meh evidence. `<strong>f/u in 3 months`</strong> sooner if ocular symptoms or new/worsening neurological symptoms
   </p>
   <p>
   Counsel: recover starts in 2-3 weeks, typically complete in 3-4months. HBVI (complete paralysis): 70% chance of recovery. HB1→HBV: 94% of recovery.
@@ -1307,7 +1307,7 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Sudden Sensorineural Hearing Loss - Clinical Practice Guideline
   </h4>
   <p>
-  -non-CPG recommendations are in `<em>`{=html}italics`</em>`{=html}
+  -non-CPG recommendations are in `<em>italics`</em>
   </p>
   <p>
   -audiometric criteria: decrease in hearing of \>30db in 3 consecutive frequencies
@@ -1442,7 +1442,7 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   </li>
   <li>
   <p>
-  `<strong>`{=html}Postop`</strong>`{=html}: f/u 2 weeks, glasscock/cotton in ear x2 days (remove POD#2), 1 week antibiotics (Augmentin preferred), drops start POD#2, bacitracin x1 week. No Narcotics.
+  `<strong>Postop`</strong>: f/u 2 weeks, glasscock/cotton in ear x2 days (remove POD#2), 1 week antibiotics (Augmentin preferred), drops start POD#2, bacitracin x1 week. No Narcotics.
   </p>
   </li>
   </ul>
@@ -1480,16 +1480,16 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Temporal Bone Lab
   </h1>
   <p>
-  `<strong>`{=html}Location`</strong>`{=html}: 4`<sup>`{=html}th`</sup>`{=html} floor of the Boston Dispensary. Get a key made
+  `<strong>Location`</strong>: 4`<sup>th`</sup> floor of the Boston Dispensary. Get a key made
   </p>
   <p>
-  `<strong>`{=html}Temporal Bone Harvest`</strong>`{=html}: At the end of the MD and PA anatomy courses in March/April. Speak to Michael Doyle at Tufts
+  `<strong>Temporal Bone Harvest`</strong>: At the end of the MD and PA anatomy courses in March/April. Speak to Michael Doyle at Tufts
   </p>
   <p>
   Set up your station according to the House Dissection Manuel
   </p>
   <p>
-  `<strong>`{=html}Steps to a Mastoidectomy / Cochlear implant:`</strong>`{=html}
+  `<strong>Steps to a Mastoidectomy / Cochlear implant:`</strong>
   </p>
   <ul>
   <li>
@@ -1542,42 +1542,42 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Cranial Nerves
   </h1>
   <p>
-  `<strong>`{=html}CNI`</strong>`{=html}: Olfactory.
+  `<strong>CNI`</strong>: Olfactory.
   </p>
   <p>
-  `<strong>`{=html}CNII`</strong>`{=html}: Optic.
+  `<strong>CNII`</strong>: Optic.
   </p>
   <p>
-  `<strong>`{=html}CNIII`</strong>`{=html}: Oculomotor --- constricts+ accommodates, innervates levator palpebrae. Moves eyes.
+  `<strong>CNIII`</strong>: Oculomotor --- constricts+ accommodates, innervates levator palpebrae. Moves eyes.
   </p>
   <p>
-  `<strong>`{=html}CNIV`</strong>`{=html}: Trochlear ---innervates superior oblique. Diplopia when looking down (walking down stairs) or watching TV in bed. Pts tilt head.
+  `<strong>CNIV`</strong>: Trochlear ---innervates superior oblique. Diplopia when looking down (walking down stairs) or watching TV in bed. Pts tilt head.
   </p>
   <p>
-  `<strong>`{=html}CNV:`</strong>`{=html} Trigeminal---sensation to face. Corneal reflex (afferent tract). Muscles innervated: Muscles of mastication (medial pterygoid, lateral pterygoid, masseter, temporalis) Suprahyoid muscles (Ant belly of digastric, mylohyoid muscle) Tensorsx2 (Tensor veli palatini & Tensor tympani). Associated w/ 1`<sup>`{=html}st`</sup>`{=html} branchial arch
+  `<strong>CNV:`</strong> Trigeminal---sensation to face. Corneal reflex (afferent tract). Muscles innervated: Muscles of mastication (medial pterygoid, lateral pterygoid, masseter, temporalis) Suprahyoid muscles (Ant belly of digastric, mylohyoid muscle) Tensorsx2 (Tensor veli palatini & Tensor tympani). Associated w/ 1`<sup>st`</sup> branchial arch
   </p>
   <p>
-  `<strong>`{=html}CNVI:`</strong>`{=html} Abducens: Innervates lateral rectus.
+  `<strong>CNVI:`</strong> Abducens: Innervates lateral rectus.
   </p>
   <p>
-  `<strong>`{=html}CNVII:`</strong>`{=html} Facial: Muscles: facial muscles (temporal, zygomatic, buccal, marginal, cervical), post. Belly of digastric, stapedius). Parasympathetic to lacrimal and submandibular glands. Taste to anterior 2/3s of tongue.
+  `<strong>CNVII:`</strong> Facial: Muscles: facial muscles (temporal, zygomatic, buccal, marginal, cervical), post. Belly of digastric, stapedius). Parasympathetic to lacrimal and submandibular glands. Taste to anterior 2/3s of tongue.
   </p>
   <p>
-  `<strong>`{=html}CNVIII:`</strong>`{=html} Vestibulocochlear--- hearing & balance.
+  `<strong>CNVIII:`</strong> Vestibulocochlear--- hearing & balance.
   </p>
   <p>
-  `<strong>`{=html}CNIX:`</strong>`{=html} Glossopharyngeal--- muscle: stylopharyngeus. Parasympathetics to parotid. Taste: posterior 1/3 of tongue. Visceral afferent: info from carotid sinus&body. Sensation to middle ear, pharynx (afferent limb of gag reflex) Associated w/ 3`<sup>`{=html}rd`</sup>`{=html} branchial arch.
+  `<strong>CNIX:`</strong> Glossopharyngeal--- muscle: stylopharyngeus. Parasympathetics to parotid. Taste: posterior 1/3 of tongue. Visceral afferent: info from carotid sinus&body. Sensation to middle ear, pharynx (afferent limb of gag reflex) Associated w/ 3`<sup>rd`</sup> branchial arch.
   </p>
   <p>
-  `<strong>`{=html}CNX:`</strong>`{=html} Vagus --- muscles: cricothyroid, levator veli palatini (lifts palate), salpingopharyngeus, palatoglossus, palatopharyngeus, pharyngeal constructors, muscles of larynx. Sensation to dura, larynx, Arnold's nerve (sensation in ear canal). Parasympathetic to abdomen heart (innervates SA/AV node).
+  `<strong>CNX:`</strong> Vagus --- muscles: cricothyroid, levator veli palatini (lifts palate), salpingopharyngeus, palatoglossus, palatopharyngeus, pharyngeal constructors, muscles of larynx. Sensation to dura, larynx, Arnold's nerve (sensation in ear canal). Parasympathetic to abdomen heart (innervates SA/AV node).
   </p>
   <p>
-  `<strong>`{=html}CNXI`</strong>`{=html} -- Spinal Accessory --- innervates SCM, trapezius.
+  `<strong>CNXI`</strong> -- Spinal Accessory --- innervates SCM, trapezius.
   </p>
   <p>
-  `<strong>`{=html}CNXII`</strong>`{=html}: Hypoglossal --- all muscles of tongue except palatoglossus
+  `<strong>CNXII`</strong>: Hypoglossal --- all muscles of tongue except palatoglossus
   </p>
   <!-- END Otology section -->
   <p>
-  `<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+  `<a href="index.html">Back to homepage`</a>
   </p>

--- a/otology/clinic-guide.md
+++ b/otology/clinic-guide.md
@@ -38,7 +38,7 @@ Keep the plans short. Put a plan for each problem listed.
 <ul>
 <li>
 <p>
-`<img alt="" src="../media/image3.png" style="width:1.16111in;height:1.14028in" />`{=html}including discussions regarding dry ear precautions. Put observation if no specific plan was proposed
+`<img alt="" src="../media/image3.png" style="width:1.16111in;height:1.14028in" />including discussions regarding dry ear precautions. Put observation if no specific plan was proposed
 </p>
 </li>
 </ul>
@@ -60,28 +60,28 @@ Audiology
 <ul>
 <li>
 <p>
-`<strong>`{=html}PTA (pure tone)`</strong>`{=html}: Hearing sensitivity at 500,1000,2000Hz
+`<strong>PTA (pure tone)`</strong>: Hearing sensitivity at 500,1000,2000Hz
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}SRT`</strong>`{=html} - lowest threshold `<strong>`{=html}spondee`</strong>`{=html} can be repeated 50% of time
+`<strong>SRT`</strong> - lowest threshold `<strong>spondee`</strong> can be repeated 50% of time
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}WRS (word rec)`</strong>`{=html} - % correct of a 50 word list of `<u>`{=html}monosyllabic phonetically balanced words.`</u>`{=html} Given at 40dB greater than SRT
+`<strong>WRS (word rec)`</strong> - % correct of a 50 word list of `<u>monosyllabic phonetically balanced words.`</u> Given at 40dB greater than SRT
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Hearing loss levels:`</strong>`{=html} go down by 15dB starting at \<25dB
+`<strong>Hearing loss levels:`</strong> go down by 15dB starting at \<25dB
 </p>
 </li>
 </ul>
 <blockquote>
 <p>
-`<img alt="" src="../media/image4.emf" style="width:1.65347in;height:1.54792in" />`{=html}`<strong>`{=html}Audiogram symbols`</strong>`{=html}: Right = O, Left = X (triangle for right masking, square for left masking → THINK ROLEX)
+`<img alt="" src="../media/image4.emf" style="width:1.65347in;height:1.54792in" />`<strong>Audiogram symbols`</strong>: Right = O, Left = X (triangle for right masking, square for left masking → THINK ROLEX)
 </p>
 </blockquote>
 <h4 class="unnumbered" id="audiogram-patterns">
@@ -90,22 +90,22 @@ Audiogram Patterns
 <ol type="A">
 <li>
 <p>
-`<strong>`{=html}2kHz notch`</strong>`{=html} (air-bone) otosclerosis
+`<strong>2kHz notch`</strong> (air-bone) otosclerosis
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}4kHz notch`</strong>`{=html} (SNHL) - noise exposure
+`<strong>4kHz notch`</strong> (SNHL) - noise exposure
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Cookie bite`</strong>`{=html} -- hereditary
+`<strong>Cookie bite`</strong> -- hereditary
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Low Frequency`</strong>`{=html} (SNHL) --- Meniere's
+`<strong>Low Frequency`</strong> (SNHL) --- Meniere's
 </p>
 </li>
 </ol>
@@ -114,10 +114,10 @@ Tympanometry
 </h4>
 <blockquote>
 <p>
-`<strong>`{=html}Ad = `<u>`{=html}D`</u>`{=html}`</strong>`{=html}eep for `<strong>`{=html}`<u>`{=html}d`</u>`{=html}`</strong>`{=html}iscontinuity
+`<strong>Ad = `<u>D`</u>`</strong>eep for `<strong>`<u>d`</u>`</strong>iscontinuity
 </p>
 <p>
-As= `<strong>`{=html}`<u>`{=html}s`</u>`{=html}`</strong>`{=html}hallow for oto`<strong>`{=html}`<u>`{=html}s`</u>`{=html}`</strong>`{=html}clerosis /ossicular fixation
+As= `<strong>`<u>s`</u>`</strong>hallow for oto`<strong>`<u>s`</u>`</strong>clerosis /ossicular fixation
 </p>
 <p>
 B + volume wnl: OME
@@ -136,22 +136,22 @@ Acoustic Reflex Testing
 Image to the right are common patterns (Red = absent. Green = present)
 </p>
 <p>
-`<strong>`{=html}Right/Left`</strong>`{=html}: the side of the sound stimulus.
+`<strong>Right/Left`</strong>: the side of the sound stimulus.
 </p>
 <p>
-`<strong>`{=html}Ipsilateral/Contralateral`</strong>`{=html}: side that the reflect stimulus is detected.
+`<strong>Ipsilateral/Contralateral`</strong>: side that the reflect stimulus is detected.
 </p>
 <p>
-`<strong>`{=html}Note`</strong>`{=html}: Acoustic reflexes should be `<u>`{=html}absent`</u>`{=html} in `<u>`{=html}CHL`</u>`{=html} (otosclerosis etc) `<u>`{=html}unless`</u>`{=html} patients have `<u>`{=html}semicircular canal dehiscence.`</u>`{=html}
+`<strong>Note`</strong>: Acoustic reflexes should be `<u>absent`</u> in `<u>CHL`</u> (otosclerosis etc) `<u>unless`</u> patients have `<u>semicircular canal dehiscence.`</u>
 </p>
 <p>
-`<strong>`{=html}OAEs`</strong>`{=html}: `<u>`{=html}T`</u>`{=html}`<strong>`{=html}EOAE - newborn testing.`</strong>`{=html} `<u>`{=html}D`</u>`{=html}POAE - think `<u>`{=html}d`</u>`{=html}ouble tones (2 pure-tone freq.) DPOAE are good f or screening ototoxicity/noise toxicity
+`<strong>OAEs`</strong>: `<u>T`</u>`<strong>EOAE - newborn testing.`</strong> `<u>D`</u>POAE - think `<u>d`</u>ouble tones (2 pure-tone freq.) DPOAE are good f or screening ototoxicity/noise toxicity
 </p>
 <p>
-`<strong>`{=html}ECoG`</strong>`{=html}: Basically measuring Wave I on a ABR. The big thing to know is `<strong>`{=html}`<u>`{=html}\>0.45 SP/AP`</u>`{=html}`</strong>`{=html} is associated with `<strong>`{=html}`<u>`{=html}Meniere's`</u>`{=html}`</strong>`{=html}
+`<strong>ECoG`</strong>: Basically measuring Wave I on a ABR. The big thing to know is `<strong>`<u>\>0.45 SP/AP`</u>`</strong> is associated with `<strong>`<u>Meniere's`</u>`</strong>
 </p>
 <p>
-`<strong>`{=html}ABR`</strong>`{=html}: `<strong>`{=html}`<u>`{=html}Wave V latency`</u>`{=html}`</strong>`{=html} (\>0.2ms) due to retrocochlear pathology
+`<strong>ABR`</strong>: `<strong>`<u>Wave V latency`</u>`</strong> (\>0.2ms) due to retrocochlear pathology
 </p>
 <ol type="A">
 <li>
@@ -161,5 +161,5 @@ Abnormal wave I-V and III-V latency = CHL
 </li>
 </ol>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>

--- a/otology/index.md
+++ b/otology/index.md
@@ -4,15 +4,15 @@ title: Otology
 ---
 <ul>
 <li>
-`<a href="clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="neuro-otology-imaging.html">`{=html}Neuro-otology Imaging`</a>`{=html}
+`<a href="neuro-otology-imaging.html">Neuro-otology Imaging`</a>
 </li>
 <li>
-`<a href="otitis.html">`{=html}Otitis`</a>`{=html}
+`<a href="otitis.html">Otitis`</a>
 </li>
 <li>
-`<a href="or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="or-guide.html">OR Guide`</a>
 </li>
 </ul>

--- a/otology/neuro-otology-imaging.md
+++ b/otology/neuro-otology-imaging.md
@@ -6,22 +6,22 @@ title: Neuro-otology Imaging
 Neuro-otology Imaging
 </h2>
 <p>
-`<strong>`{=html}CT Temporal Bone`</strong>`{=html}:
+`<strong>CT Temporal Bone`</strong>:
 </p>
 <p>
-`<strong>`{=html}Stenvers/Perpendicular`</strong>`{=html} view: a long-axis projection of the petrous portion of the temporal bone, perpendicular to axis of cochlear (best for seeing cochlear implant electrode array) and is used to depict the `<strong>`{=html}round`</strong>`{=html} window, `<strong>`{=html}tegmen`</strong>`{=html}, as well as other structures.
+`<strong>Stenvers/Perpendicular`</strong> view: a long-axis projection of the petrous portion of the temporal bone, perpendicular to axis of cochlear (best for seeing cochlear implant electrode array) and is used to depict the `<strong>round`</strong> window, `<strong>tegmen`</strong>, as well as other structures.
 </p>
 <p>
-The `<strong>`{=html}Poschl/Parallel`</strong>`{=html} view, a short-axis view of the petrous pyramid, was used to optimally visualize the `<strong>`{=html}superior semicircular canal`</strong>`{=html}
+The `<strong>Poschl/Parallel`</strong> view, a short-axis view of the petrous pyramid, was used to optimally visualize the `<strong>superior semicircular canal`</strong>
 </p>
 <h4 class="unnumbered" id="how-to-read-temporal-bone-images">
 How to Read Temporal Bone Images
 </h4>
 <p>
-`<strong>`{=html}Divide into:`</strong>`{=html} EAC, Middle Ear, Inner Ear, Petrous Apex, Intratemporal Facial Nerve
+`<strong>Divide into:`</strong> EAC, Middle Ear, Inner Ear, Petrous Apex, Intratemporal Facial Nerve
 </p>
 <p>
-`<strong>`{=html}External Auditory Canal (EAC):`</strong>`{=html}
+`<strong>External Auditory Canal (EAC):`</strong>
 </p>
 <ul>
 <li>
@@ -56,7 +56,7 @@ Canal Atresia/Stenosis: look at ossicles -- malleus/incus are typically fused. O
 </li>
 </ul>
 <p>
-`<strong>`{=html}Middle Ear`</strong>`{=html}
+`<strong>Middle Ear`</strong>
 </p>
 <ul>
 <li>
@@ -76,7 +76,7 @@ Glomus Tympanicum: oval mass of cochlear promontory
 </li>
 </ul>
 <p>
-`<strong>`{=html}Inner Ear`</strong>`{=html}
+`<strong>Inner Ear`</strong>
 </p>
 <ul>
 <li>
@@ -113,7 +113,7 @@ Otosclerosis: demineralized bone over otic capsule
 </li>
 </ul>
 <p>
-`<strong>`{=html}Petrous Apex`</strong>`{=html}
+`<strong>Petrous Apex`</strong>
 </p>
 <ul>
 <li>
@@ -138,7 +138,7 @@ Chondrosarcoma: look for intratumoral calcification
 </li>
 </ul>
 <p>
-`<strong>`{=html}Intratemporal Fossa`</strong>`{=html}
+`<strong>Intratemporal Fossa`</strong>
 </p>
 <ul>
 <li>
@@ -158,10 +158,10 @@ Epidermoids: : T1 hypointense and T2 hyperintense, doesn't enhance. Differentiat
 </li>
 </ul>
 <p>
-`<img alt="" src="../media/image5.png" style="width:3.75841in;height:3.04933in" />`{=html}
+`<img alt="" src="../media/image5.png" style="width:3.75841in;height:3.04933in" />
 </p>
 <p>
-`<em>`{=html}Image:`</em>`{=html} Adunka and Buchman, `<em>`{=html}Otology, Neurotology, and Lateral Skull Base Surgery`</em>`{=html}
+`<em>Image:`</em> Adunka and Buchman, `<em>Otology, Neurotology, and Lateral Skull Base Surgery`</em>
 </p>
 <p>
 .
@@ -170,7 +170,7 @@ Epidermoids: : T1 hypointense and T2 hyperintense, doesn't enhance. Differentiat
 MRI Internal Auditory Canal
 </h4>
 <p>
-`<strong>`{=html}General principles of MRI:`</strong>`{=html}
+`<strong>General principles of MRI:`</strong>
 </p>
 <table>
 <colgroup>
@@ -673,7 +673,7 @@ Test cranial nerves
 </li>
 <li>
 <p>
-Nystagmus: `<strong>`{=html}nystagmus named in direction of fast phase`</strong>`{=html}
+Nystagmus: `<strong>nystagmus named in direction of fast phase`</strong>
 </p>
 <ol type="A">
 <li>
@@ -710,12 +710,12 @@ Check for BPPV:
 <ol type="A">
 <li>
 <p>
-`<strong>`{=html}Dix Hallpike`</strong>`{=html}: have head turned to one side then drop patient flat with head hanging slightly backwards. Repeat for both sides. Rotatory nystagmus occurs on the side of the lesion. Posterior SCC most common site
+`<strong>Dix Hallpike`</strong>: have head turned to one side then drop patient flat with head hanging slightly backwards. Repeat for both sides. Rotatory nystagmus occurs on the side of the lesion. Posterior SCC most common site
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Head-shake test:`</strong>`{=html}
+`<strong>Head-shake test:`</strong>
 </p>
 </li>
 </ol>
@@ -723,13 +723,13 @@ Check for BPPV:
 </ol>
 <blockquote>
 <p>
-Ask patient to close eyes then shake head (lateral rotation left and right) twice a second (2Hz) for 15-20 seconds. Ask them to open eyes. `<strong>`{=html}Fast phase = towards lesion`</strong>`{=html}
+Ask patient to close eyes then shake head (lateral rotation left and right) twice a second (2Hz) for 15-20 seconds. Ask them to open eyes. `<strong>Fast phase = towards lesion`</strong>
 </p>
 </blockquote>
 <ol start="3" type="A">
 <li>
 <p>
-`<strong>`{=html}Head Impulse test/Head Trust`</strong>`{=html}
+`<strong>Head Impulse test/Head Trust`</strong>
 </p>
 </li>
 </ol>
@@ -741,7 +741,7 @@ Hold head and quickly rotate it toward one ear while patient fixates on your nos
 <ol start="4" type="A">
 <li>
 <p>
-`<strong>`{=html}Oscillopsia test`</strong>`{=html}: a quick test to evaluate for bilateral vestibular loss: Have patient do a head shake test while reading a snellen chart. If visual acuity significantly different than at rest, suspect b/l vestibular dysfunction
+`<strong>Oscillopsia test`</strong>: a quick test to evaluate for bilateral vestibular loss: Have patient do a head shake test while reading a snellen chart. If visual acuity significantly different than at rest, suspect b/l vestibular dysfunction
 </p>
 </li>
 </ol>
@@ -749,7 +749,7 @@ Hold head and quickly rotate it toward one ear while patient fixates on your nos
 Additional testing
 </p>
 <p>
-`<img src="../media/image6.png" style="width:1.65764in;height:0.925in" alt="Machine generated alternative text: Right Right beating nystagmus Fast beat Horizontal Slow beat Left beating nystagmus Left Slow beat Fast beat " />`{=html}`<strong>`{=html}VNG/ENG`</strong>`{=html}: If you have a nystagmus graph. Use ur arms to determine which side. Ur left arm can be parallel to left sided slow beating.
+`<img src="../media/image6.png" style="width:1.65764in;height:0.925in" alt="Machine generated alternative text: Right Right beating nystagmus Fast beat Horizontal Slow beat Left beating nystagmus Left Slow beat Fast beat " />`<strong>VNG/ENG`</strong>: If you have a nystagmus graph. Use ur arms to determine which side. Ur left arm can be parallel to left sided slow beating.
 </p>
 <h4 class="unnumbered" id="caloric-testing">
 Caloric Testing
@@ -820,7 +820,7 @@ Phase lead - exaggerated in peripheral disease
 </li>
 </ul>
 <p>
-`<strong>`{=html}VEMP`</strong>`{=html} (cervical to SCM)
+`<strong>VEMP`</strong> (cervical to SCM)
 </p>
 <ul>
 <li>
@@ -835,17 +835,17 @@ oVEMP evaluates utricle (horizontal acceleration) -\> superior vestibular nerve
 </li>
 <li>
 <p>
-Unilateral decreased `<strong>`{=html}amplitude`</strong>`{=html} - peripheral lesion
+Unilateral decreased `<strong>amplitude`</strong> - peripheral lesion
 </p>
 </li>
 <li>
 <p>
-Decreased `<strong>`{=html}threshold`</strong>`{=html} - SCC dehiscence or perilymph fistula
+Decreased `<strong>threshold`</strong> - SCC dehiscence or perilymph fistula
 </p>
 </li>
 <li>
 <p>
-Increased `<strong>`{=html}threshold`</strong>`{=html} - middle ear pathology or ossicular chain abnormalities
+Increased `<strong>threshold`</strong> - middle ear pathology or ossicular chain abnormalities
 </p>
 </li>
 </ul>
@@ -855,12 +855,12 @@ Other
 <ol type="1">
 <li>
 <p>
-`<strong>`{=html}vHIT`</strong>`{=html}: basically a recorded head impulse test
+`<strong>vHIT`</strong>: basically a recorded head impulse test
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Computer Dynamic Posturography`</strong>`{=html}: expensive test to test proprioception
+`<strong>Computer Dynamic Posturography`</strong>: expensive test to test proprioception
 </p>
 </li>
 </ol>
@@ -886,7 +886,7 @@ Causes of Vertigo
 Perilymph Fistula
 </h4>
 <p>
--sudden `<u>`{=html}SNHL w/ vertigo`</u>`{=html} s/p trauma
+-sudden `<u>SNHL w/ vertigo`</u> s/p trauma
 </p>
 <p>
 -Tullio's phenomenon (vertigo w/ loud sound) Hennebert's sign: (vertigo w/ pneumatoscopy)
@@ -901,7 +901,7 @@ Superior Semicircular Canal Dehiscence
 -vertigo, autophony, Tullio's & Hennebert's sign, aural fullness
 </p>
 <p>
--Audiogram: CHL, supernormal bone conduction. cVEMP (↓threshold, ↑amplitude), `<strong>`{=html}acoustic reflexes are present`</strong>`{=html}
+-Audiogram: CHL, supernormal bone conduction. cVEMP (↓threshold, ↑amplitude), `<strong>acoustic reflexes are present`</strong>
 </p>
 <p>
 -CT Temporal Bone: Get Porshl's view
@@ -919,16 +919,16 @@ BPPV - Clinical Practice Guideline
 -Assess patient's home safety/risk of falling + ability to perform Epley
 </p>
 <p>
-\-`<strong>`{=html}No`</strong>`{=html} i`<strong>`{=html}maging or vestibular testing or vestibular suppressants`</strong>`{=html} for those who have symptoms+exam findings of BPPV
+\-`<strong>No`</strong> i`<strong>maging or vestibular testing or vestibular suppressants`</strong> for those who have symptoms+exam findings of BPPV
 </p>
 <p>
--Can offer observation, vestibular rehab, or Epley maneuver: Dix hall pike to the offending side. Wait for nystagmus to stop, rotate head to contralateral side. `<strong>`{=html}Hold head`</strong>`{=html} and ask patient to rotate onto stomach, then have them tuck heels to bum and sit up. `<strong>`{=html}Repeat`</strong>`{=html} until nystagmus is gone
+-Can offer observation, vestibular rehab, or Epley maneuver: Dix hall pike to the offending side. Wait for nystagmus to stop, rotate head to contralateral side. `<strong>Hold head`</strong> and ask patient to rotate onto stomach, then have them tuck heels to bum and sit up. `<strong>Repeat`</strong> until nystagmus is gone
 </p>
 <p>
 -can do Semont maneuver. Ask patient to keep head elevated for 48hours.
 </p>
 <p>
--patients w/ migraines and motion refractory take longer to recover. `<u>`{=html}F/u in 4-6 weeks`</u>`{=html}. If refractory, send to neurology to r/o migraines and get MRI to r/o retrocochlear pathology.
+-patients w/ migraines and motion refractory take longer to recover. `<u>F/u in 4-6 weeks`</u>. If refractory, send to neurology to r/o migraines and get MRI to r/o retrocochlear pathology.
 </p>
 <p>
 -surgery Tx: singular Neuroectomy (historic) posterior SCC occlusion (pack Posterior SCC with bone wax)
@@ -946,13 +946,13 @@ Dx: Audiogram & ECoG: SP/AP \>0.35
 Tx: restrict salt intake \<1.5g/day, avoid EtOH, caffeine, even out water consumption
 </p>
 <p>
-`<strong>`{=html}Acute Vertigo`</strong>`{=html} (diazepam 5-10mg q12hrs/lorazepam 0.5-1mg q6hrs + zofran 4mg q8hrs +/- Benadryl 25-50mg q4-6hrs)
+`<strong>Acute Vertigo`</strong> (diazepam 5-10mg q12hrs/lorazepam 0.5-1mg q6hrs + zofran 4mg q8hrs +/- Benadryl 25-50mg q4-6hrs)
 </p>
 <p>
-`<strong>`{=html}Maintenance therapy`</strong>`{=html}: HCTZ 50mg qdaily
+`<strong>Maintenance therapy`</strong>: HCTZ 50mg qdaily
 </p>
 <p>
-`<strong>`{=html}Surgery`</strong>`{=html}: endolymphatic sac decompression, transtympanic gentamycin injection (0.5 to 0.75 mL of a 40 mg/mL solution of gentamicin into middle ear space)
+`<strong>Surgery`</strong>: endolymphatic sac decompression, transtympanic gentamycin injection (0.5 to 0.75 mL of a 40 mg/mL solution of gentamicin into middle ear space)
 </p>
 <h4 class="unnumbered" id="other-causes-of-vertigo">
 Other causes of vertigo
@@ -964,5 +964,5 @@ Cogan Syndrome: if patients have rapidly progressing blurry vision (interstitial
 Labyrinthine Concussion: BPPV like symptoms after trauma
 </p>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>

--- a/otology/or-guide.md
+++ b/otology/or-guide.md
@@ -76,7 +76,7 @@ Incision 1cm behind postauricular crease. Then switch to bovie down to TPF. Find
 </li>
 <li>
 <p>
-`<strong>`{=html}Postop`</strong>`{=html}: f/u 2 weeks, glasscock/cotton in ear x2 days (remove POD#2), 1 week antibiotics (Augmentin preferred), drops start POD#2, bacitracin x1 week. No Narcotics.
+`<strong>Postop`</strong>: f/u 2 weeks, glasscock/cotton in ear x2 days (remove POD#2), 1 week antibiotics (Augmentin preferred), drops start POD#2, bacitracin x1 week. No Narcotics.
 </p>
 </li>
 </ul>
@@ -114,16 +114,16 @@ Harvests TPF and TF if graft is needed
 Temporal Bone Lab
 </h1>
 <p>
-`<strong>`{=html}Location`</strong>`{=html}: 4`<sup>`{=html}th`</sup>`{=html} floor of the Boston Dispensary. Get a key made
+`<strong>Location`</strong>: 4`<sup>th`</sup> floor of the Boston Dispensary. Get a key made
 </p>
 <p>
-`<strong>`{=html}Temporal Bone Harvest`</strong>`{=html}: At the end of the MD and PA anatomy courses in March/April. Speak to Michael Doyle at Tufts
+`<strong>Temporal Bone Harvest`</strong>: At the end of the MD and PA anatomy courses in March/April. Speak to Michael Doyle at Tufts
 </p>
 <p>
 Set up your station according to the House Dissection Manuel
 </p>
 <p>
-`<strong>`{=html}Steps to a Mastoidectomy / Cochlear implant:`</strong>`{=html}
+`<strong>Steps to a Mastoidectomy / Cochlear implant:`</strong>
 </p>
 <ul>
 <li>
@@ -176,42 +176,42 @@ Switch to a 2 coarse diamond: start drilling the facial recess. There are some a
 Cranial Nerves
 </h1>
 <p>
-`<strong>`{=html}CNI`</strong>`{=html}: Olfactory.
+`<strong>CNI`</strong>: Olfactory.
 </p>
 <p>
-`<strong>`{=html}CNII`</strong>`{=html}: Optic.
+`<strong>CNII`</strong>: Optic.
 </p>
 <p>
-`<strong>`{=html}CNIII`</strong>`{=html}: Oculomotor --- constricts+ accommodates, innervates levator palpebrae. Moves eyes.
+`<strong>CNIII`</strong>: Oculomotor --- constricts+ accommodates, innervates levator palpebrae. Moves eyes.
 </p>
 <p>
-`<strong>`{=html}CNIV`</strong>`{=html}: Trochlear ---innervates superior oblique. Diplopia when looking down (walking down stairs) or watching TV in bed. Pts tilt head.
+`<strong>CNIV`</strong>: Trochlear ---innervates superior oblique. Diplopia when looking down (walking down stairs) or watching TV in bed. Pts tilt head.
 </p>
 <p>
-`<strong>`{=html}CNV:`</strong>`{=html} Trigeminal---sensation to face. Corneal reflex (afferent tract). Muscles innervated: Muscles of mastication (medial pterygoid, lateral pterygoid, masseter, temporalis) Suprahyoid muscles (Ant belly of digastric, mylohyoid muscle) Tensorsx2 (Tensor veli palatini & Tensor tympani). Associated w/ 1`<sup>`{=html}st`</sup>`{=html} branchial arch
+`<strong>CNV:`</strong> Trigeminal---sensation to face. Corneal reflex (afferent tract). Muscles innervated: Muscles of mastication (medial pterygoid, lateral pterygoid, masseter, temporalis) Suprahyoid muscles (Ant belly of digastric, mylohyoid muscle) Tensorsx2 (Tensor veli palatini & Tensor tympani). Associated w/ 1`<sup>st`</sup> branchial arch
 </p>
 <p>
-`<strong>`{=html}CNVI:`</strong>`{=html} Abducens: Innervates lateral rectus.
+`<strong>CNVI:`</strong> Abducens: Innervates lateral rectus.
 </p>
 <p>
-`<strong>`{=html}CNVII:`</strong>`{=html} Facial: Muscles: facial muscles (temporal, zygomatic, buccal, marginal, cervical), post. Belly of digastric, stapedius). Parasympathetic to lacrimal and submandibular glands. Taste to anterior 2/3s of tongue.
+`<strong>CNVII:`</strong> Facial: Muscles: facial muscles (temporal, zygomatic, buccal, marginal, cervical), post. Belly of digastric, stapedius). Parasympathetic to lacrimal and submandibular glands. Taste to anterior 2/3s of tongue.
 </p>
 <p>
-`<strong>`{=html}CNVIII:`</strong>`{=html} Vestibulocochlear--- hearing & balance.
+`<strong>CNVIII:`</strong> Vestibulocochlear--- hearing & balance.
 </p>
 <p>
-`<strong>`{=html}CNIX:`</strong>`{=html} Glossopharyngeal--- muscle: stylopharyngeus. Parasympathetics to parotid. Taste: posterior 1/3 of tongue. Visceral afferent: info from carotid sinus&body. Sensation to middle ear, pharynx (afferent limb of gag reflex) Associated w/ 3`<sup>`{=html}rd`</sup>`{=html} branchial arch.
+`<strong>CNIX:`</strong> Glossopharyngeal--- muscle: stylopharyngeus. Parasympathetics to parotid. Taste: posterior 1/3 of tongue. Visceral afferent: info from carotid sinus&body. Sensation to middle ear, pharynx (afferent limb of gag reflex) Associated w/ 3`<sup>rd`</sup> branchial arch.
 </p>
 <p>
-`<strong>`{=html}CNX:`</strong>`{=html} Vagus --- muscles: cricothyroid, levator veli palatini (lifts palate), salpingopharyngeus, palatoglossus, palatopharyngeus, pharyngeal constructors, muscles of larynx. Sensation to dura, larynx, Arnold's nerve (sensation in ear canal). Parasympathetic to abdomen heart (innervates SA/AV node).
+`<strong>CNX:`</strong> Vagus --- muscles: cricothyroid, levator veli palatini (lifts palate), salpingopharyngeus, palatoglossus, palatopharyngeus, pharyngeal constructors, muscles of larynx. Sensation to dura, larynx, Arnold's nerve (sensation in ear canal). Parasympathetic to abdomen heart (innervates SA/AV node).
 </p>
 <p>
-`<strong>`{=html}CNXI`</strong>`{=html} -- Spinal Accessory --- innervates SCM, trapezius.
+`<strong>CNXI`</strong> -- Spinal Accessory --- innervates SCM, trapezius.
 </p>
 <p>
-`<strong>`{=html}CNXII`</strong>`{=html}: Hypoglossal --- all muscles of tongue except palatoglossus
+`<strong>CNXII`</strong>: Hypoglossal --- all muscles of tongue except palatoglossus
 </p>
 <!-- END Otology section -->
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>

--- a/otology/otitis.md
+++ b/otology/otitis.md
@@ -11,12 +11,12 @@ Acute Otitis Externa -- Clinical Practice Guideline
 <ul>
 <li>
 <p>
-`<img alt="" src="../media/image7.jpeg" style="width:0.88194in;height:0.86944in" />`{=html}`<strong>`{=html}Diagnosis`</strong>`{=html}: rapid onset (over 2 days) + ear pain, itchiness, fullness + EITHER signs of ear canal fullness (tenderness of tragus/pinnae) OR diffuse canal edema. Otorrhea is not needed for diagnosis. `<strong>`{=html}MCC`</strong>`{=html}: P aeruginosa + staph aureus. `<strong>`{=html}Eval for`</strong>`{=html}: Hx of T2DM, HIV, hx of XRT/immunocompromised. `<strong>`{=html}Check for`</strong>`{=html} TM perforation/Tubes -- ciprodex/ofloxacin are the only drops if perforation/tubes are present. `<u>`{=html}If cranial nerve palsy or granulation tissue on inferior aspect of canal (at bony-cartilaginous junction)`</u>`{=html}: consider malignant otitis externa (which is AOE + osteomyelitis of skull base)
+`<img alt="" src="../media/image7.jpeg" style="width:0.88194in;height:0.86944in" />`<strong>Diagnosis`</strong>: rapid onset (over 2 days) + ear pain, itchiness, fullness + EITHER signs of ear canal fullness (tenderness of tragus/pinnae) OR diffuse canal edema. Otorrhea is not needed for diagnosis. `<strong>MCC`</strong>: P aeruginosa + staph aureus. `<strong>Eval for`</strong>: Hx of T2DM, HIV, hx of XRT/immunocompromised. `<strong>Check for`</strong> TM perforation/Tubes -- ciprodex/ofloxacin are the only drops if perforation/tubes are present. `<u>If cranial nerve palsy or granulation tissue on inferior aspect of canal (at bony-cartilaginous junction)`</u>: consider malignant otitis externa (which is AOE + osteomyelitis of skull base)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Tx`</strong>`{=html}: `<strong>`{=html}Topical Abx:`</strong>`{=html} Ciprodex/cipro HC, cortisporin, acetic acid (Vinegar), Vosol HC (acetic acid+hydrocortisone). Dosing should be at least BID, for 7-10days Don't give systemic antibiotics unless patients are high risk: T2DM, HIV, `<strong>`{=html}Tell patients how to apply otic drops`</strong>`{=html}: lie with affected ear up. Put drops. Tragus pump to help. Stay in position x3-5mins.
+`<strong>Tx`</strong>: `<strong>Topical Abx:`</strong> Ciprodex/cipro HC, cortisporin, acetic acid (Vinegar), Vosol HC (acetic acid+hydrocortisone). Dosing should be at least BID, for 7-10days Don't give systemic antibiotics unless patients are high risk: T2DM, HIV, `<strong>Tell patients how to apply otic drops`</strong>: lie with affected ear up. Put drops. Tragus pump to help. Stay in position x3-5mins.
 </p>
 </li>
 <li>
@@ -26,7 +26,7 @@ When to place ear wick: If EAC edema means TM cannot be seen
 </li>
 <li>
 <p>
-`<img alt="" src="../media/image8.jpeg" style="width:1.27917in;height:1.01528in" />`{=html}Follow up should be in 2-3 days
+`<img alt="" src="../media/image8.jpeg" style="width:1.27917in;height:1.01528in" />Follow up should be in 2-3 days
 </p>
 </li>
 </ul>
@@ -55,19 +55,19 @@ Chronic Otitis Externa
 -\>6weeks of persistent OE.
 </p>
 <p>
--first try `<strong>`{=html}mineral oil`</strong>`{=html} 2-3 drops at night. F/U in 2 months
+-first try `<strong>mineral oil`</strong> 2-3 drops at night. F/U in 2 months
 </p>
 <p>
--next can try `<strong>`{=html}DermOtic`</strong>`{=html} (fluocinolone) if that doesn't work
+-next can try `<strong>DermOtic`</strong> (fluocinolone) if that doesn't work
 </p>
 <h4 class="unnumbered" id="fungal-otitis-external-otomycosis">
 Fungal Otitis External (Otomycosis)
 </h4>
 <p>
-MCC: aspergillus. Exam shows sheets of keratin with black conidophores on top of white filamentous hyphae. Tx: acetic acid (vinegar) vs c`<strong>`{=html}lotrimazole 1% solution (lotrimin)`</strong>`{=html}, glucose control, dry ear precautions. Consider gentian violet or methyl-cresyl actate for refractors cases
+MCC: aspergillus. Exam shows sheets of keratin with black conidophores on top of white filamentous hyphae. Tx: acetic acid (vinegar) vs c`<strong>lotrimazole 1% solution (lotrimin)`</strong>, glucose control, dry ear precautions. Consider gentian violet or methyl-cresyl actate for refractors cases
 </p>
 <h3 class="unnumbered" id="tinnitus-clinical-practice-guideline">
-Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
+Tinnitus-`<strong>Clinical Practice Guideline`</strong>
 </h3>
 <p>
 
@@ -77,7 +77,7 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   -In general, don't get imaging. Only get imaging if tinnitus + either unilateral/asymmetric hearing loss or neurological abnormalities
   </p>
   <p>
-  -Tx: can observe for bothersome tinnitus that has lasted for \<6months. For tinnitus that is bothersome & persistent (\>6months) guideline recommends: `<strong>`{=html}sound therapy`</strong>`{=html} (white noise machine), `<strong>`{=html}cognitive behavior therapy`</strong>`{=html}, and `<strong>`{=html}hearing aids`</strong>`{=html} (ONLY IF patients have hearing loss). Guideline recommend against: dietary supplements, deep-brain stimulation, medical therapy. Dr Sillman also likely to recommend meditation.
+  -Tx: can observe for bothersome tinnitus that has lasted for \<6months. For tinnitus that is bothersome & persistent (\>6months) guideline recommends: `<strong>sound therapy`</strong> (white noise machine), `<strong>cognitive behavior therapy`</strong>, and `<strong>hearing aids`</strong> (ONLY IF patients have hearing loss). Guideline recommend against: dietary supplements, deep-brain stimulation, medical therapy. Dr Sillman also likely to recommend meditation.
   </p>
   <h3 class="unnumbered" id="otosclerosis">
   Otosclerosis
@@ -85,12 +85,12 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   <ul>
   <li>
   <p>
-  Ask: Progressive CHL beginning in 20-40yo. Strong family history (`<strong>`{=html}Autosomal Dominant w/ incomplete penetrance)`</strong>`{=html}. Often have tinnitus. Hear better in noise
+  Ask: Progressive CHL beginning in 20-40yo. Strong family history (`<strong>Autosomal Dominant w/ incomplete penetrance)`</strong>. Often have tinnitus. Hear better in noise
   </p>
   </li>
   <li>
   <p>
-  Exam: Schwartze sign (red hue behind TM). Audiogram: look for Carharts notch @ 2kHz (CO2: Carhart notch in Otosclerosis at 2Khz). Absent acoustic reflex. Shallow tympanometry (As: for Oto`<u>`{=html}s`</u>`{=html}clerosis)
+  Exam: Schwartze sign (red hue behind TM). Audiogram: look for Carharts notch @ 2kHz (CO2: Carhart notch in Otosclerosis at 2Khz). Absent acoustic reflex. Shallow tympanometry (As: for Oto`<u>s`</u>clerosis)
   </p>
   </li>
   <li>
@@ -149,25 +149,25 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Facial Nerve
   </h3>
   <p>
-  `<strong>`{=html}Intracranial segment`</strong>`{=html}: gives of Nervus intermedius -- contributes to GSPN and chorda tympani -\> `<strong>`{=html}meatal`</strong>`{=html}: through IAC to fundus -\> `<strong>`{=html}labyrinthine`</strong>`{=html}: shortest segment -- goes to geniculate ganglion and gives of GSPN \[gives off pregang. Parasymp to lacrimal gland\] -\> `<strong>`{=html}tympanic`</strong>`{=html} : goes inferior to HSCC & above oval window/stapes (which is why you down-fracture stapes) -\> mastoid segment
+  `<strong>Intracranial segment`</strong>: gives of Nervus intermedius -- contributes to GSPN and chorda tympani -\> `<strong>meatal`</strong>: through IAC to fundus -\> `<strong>labyrinthine`</strong>: shortest segment -- goes to geniculate ganglion and gives of GSPN \[gives off pregang. Parasymp to lacrimal gland\] -\> `<strong>tympanic`</strong> : goes inferior to HSCC & above oval window/stapes (which is why you down-fracture stapes) -\> mastoid segment
   </p>
   <p>
-  `<strong>`{=html}Management of FN paralysis`</strong>`{=html}:
+  `<strong>Management of FN paralysis`</strong>:
   </p>
   <ul>
   <li>
   <p>
-  `<strong>`{=html}HBI`</strong>`{=html}-`<strong>`{=html}V (Day 0-14)`</strong>`{=html}: Give 14 day course of prednisone and have them f/u within 1 week. If progressed to HBVI at f/u, get a ENoG,
+  `<strong>HBI`</strong>-`<strong>V (Day 0-14)`</strong>: Give 14 day course of prednisone and have them f/u within 1 week. If progressed to HBVI at f/u, get a ENoG,
   </p>
   </li>
   <li>
   <p>
-  `<strong>`{=html}HBVI (Day 0-3):`</strong>`{=html} Give 14 day course of prednisone, f/u within 1 week
+  `<strong>HBVI (Day 0-3):`</strong> Give 14 day course of prednisone, f/u within 1 week
   </p>
   </li>
   <li>
   <p>
-  `<strong>`{=html}HBVI (Day3-14)`</strong>`{=html}: Get ENoG. If \>90% degeneration: Get EMG: decompress nerve if EMG is negative, observe if positive. If \<90% degeneration: give Prednisone.
+  `<strong>HBVI (Day3-14)`</strong>: Get ENoG. If \>90% degeneration: Get EMG: decompress nerve if EMG is negative, observe if positive. If \<90% degeneration: give Prednisone.
   </p>
   </li>
   </ul>
@@ -175,10 +175,10 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Bell's Palsy -- Clinical Practice Guideline
   </h4>
   <p>
-  Dx: typically rapid onset unilateral FN paresis or paralysis. `<strong>`{=html}R/O stroke, parotid mass, systemic/infection`</strong>`{=html}. Ask about `<strong>`{=html}Sarcoidosis`</strong>`{=html} (Heerfordt fever). Guidelines say: `<strong>`{=html}no lab or imaging tests needed`</strong>`{=html}. If complete paralysis (HBVI) can `<em>`{=html}offer`</em>`{=html} ENoG/EMG (get after 7 days). If HBI→HBV: don't get nerve testing
+  Dx: typically rapid onset unilateral FN paresis or paralysis. `<strong>R/O stroke, parotid mass, systemic/infection`</strong>. Ask about `<strong>Sarcoidosis`</strong> (Heerfordt fever). Guidelines say: `<strong>no lab or imaging tests needed`</strong>. If complete paralysis (HBVI) can `<em>offer`</em> ENoG/EMG (get after 7 days). If HBI→HBV: don't get nerve testing
   </p>
   <p>
-  Tx: `<strong>`{=html}eye protection`</strong>`{=html}: tape eyes shut at night, eye drops + `<strong>`{=html}steroids within 72hrs of symptoms:`</strong>`{=html} at least 5 days of high dose then taper. Can add antivirals but meh evidence. `<strong>`{=html}f/u in 3 months`</strong>`{=html} sooner if ocular symptoms or new/worsening neurological symptoms
+  Tx: `<strong>eye protection`</strong>: tape eyes shut at night, eye drops + `<strong>steroids within 72hrs of symptoms:`</strong> at least 5 days of high dose then taper. Can add antivirals but meh evidence. `<strong>f/u in 3 months`</strong> sooner if ocular symptoms or new/worsening neurological symptoms
   </p>
   <p>
   Counsel: recover starts in 2-3 weeks, typically complete in 3-4months. HBVI (complete paralysis): 70% chance of recovery. HB1→HBV: 94% of recovery.
@@ -187,7 +187,7 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   Sudden Sensorineural Hearing Loss - Clinical Practice Guideline
   </h4>
   <p>
-  -non-CPG recommendations are in `<em>`{=html}italics`</em>`{=html}
+  -non-CPG recommendations are in `<em>italics`</em>
   </p>
   <p>
   -audiometric criteria: decrease in hearing of \>30db in 3 consecutive frequencies
@@ -249,5 +249,5 @@ Tinnitus-`<strong>`{=html}Clinical Practice Guideline`</strong>`{=html}
   </li>
   </ol>
   <p>
-  `<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+  `<a href="../index.html">Back to homepage`</a>
   </p>

--- a/pediatric-otolaryngology.md
+++ b/pediatric-otolaryngology.md
@@ -92,22 +92,22 @@ Family hx of ear disease; ankyloglossia (paternal);
 Pediatric ROS
 </h4>
 <p>
-`<strong>`{=html}Ears: No`</strong>`{=html} episodes of AOM. No otorrhea or otalgia. No
+`<strong>Ears: No`</strong> episodes of AOM. No otorrhea or otalgia. No
 concerns for hearing loss. No difficulty with balance. No history of
 speech delay.
 </p>
 <p>
-`<strong>`{=html}Nose`</strong>`{=html}: Denies chronic nasal congestion or rhinorrhea.
+`<strong>Nose`</strong>: Denies chronic nasal congestion or rhinorrhea.
 No epistaxis. No history or symptoms of environmental allergies; no
 formal allergy evaluation to date.
 </p>
 <p>
-`<strong>`{=html}Throat`</strong>`{=html}: No snoring or mouth breathing at night. No
+`<strong>Throat`</strong>: No snoring or mouth breathing at night. No
 witnessed apneic pauses in breathing while sleeping. No nighttime
 enuresis. No episodes of tonsillitis or frequent sore throats.
 </p>
 <p>
-`<strong>`{=html}Airway`</strong>`{=html}: No dysphagia or odynophagia. Denies any
+`<strong>Airway`</strong>: No dysphagia or odynophagia. Denies any
 change in sound of voice or cry, no hoarseness. No gasping or choking
 spells. No episodes of respiratory distress. (Stridor/how's the
 patient's cry, choking w. food/hx of respiration PNA, weight loss/FTT,
@@ -118,35 +118,35 @@ OME -
 Clinical Practice Guidelines
 </h3>
 <p>
-`<strong>`{=html}Recurrent AOM:`</strong>`{=html} 3 discrete episodes of AOM in 6months
+`<strong>Recurrent AOM:`</strong> 3 discrete episodes of AOM in 6months
 or 4 in past 12 months
 </p>
 <p>
-`<strong>`{=html}Chronic OME`</strong>`{=html}: OME that persists for 3+ months
+`<strong>Chronic OME`</strong>: OME that persists for 3+ months
 </p>
 <p>
 Always use pneumatic otoscopy. Tympanometry if diagnosis is
 uncertain. Council parents of newborns who fail NBHS of importance of
 f/u due to risk of SNHL. Should screen of OME in at-risk patients.
-`<strong>`{=html}Watchful waiting recommended for`</strong>`{=html} c`<strong>`{=html}hild with OME
-w/o risk factors.`</strong>`{=html} Don't give steroids, antihistamines, or
-decongestants to childrens with OME. `<strong>`{=html}OME \>3months -- get
-audiogram`</strong>`{=html}. Re-eval patients with OME q3-6months until OME no
+`<strong>Watchful waiting recommended for`</strong> c`<strong>hild with OME
+w/o risk factors.`</strong> Don't give steroids, antihistamines, or
+decongestants to childrens with OME. `<strong>OME \>3months -- get
+audiogram`</strong>. Re-eval patients with OME q3-6months until OME no
 longer present or hearing loss identified (yes, repeat hearing test
 q3-6months) or structural abnormalities/middle ear disease suspected.
-`<strong>`{=html}Chronic OME + hearing loss or symptoms that are consistent w/
-hearing loss`</strong>`{=html} -- book for tympanostomy tube placement.
-`<strong>`{=html}Recurrent AOM`</strong>`{=html}: book for tympanostomy tube placement if
-OME seen on day of visit. `<strong>`{=html}Patients \>4yo should get an
-adenoidectomy with ear tubes.`</strong>`{=html}
+`<strong>Chronic OME + hearing loss or symptoms that are consistent w/
+hearing loss`</strong> -- book for tympanostomy tube placement.
+`<strong>Recurrent AOM`</strong>: book for tympanostomy tube placement if
+OME seen on day of visit. `<strong>Patients \>4yo should get an
+adenoidectomy with ear tubes.`</strong>
 </p>
 <p>
-`<strong>`{=html}SRBD/OSA`</strong>`{=html}
+`<strong>SRBD/OSA`</strong>
 </p>
 <ul>
 <li>
 <p>
-Obtain PSG if: (1) obese \>95`<sup>`{=html}th`</sup>`{=html} %ile (2) down
+Obtain PSG if: (1) obese \>95`<sup>th`</sup> %ile (2) down
 syndrome (3) craniofacial disorder (4) neuromuscular disorder (5) sickle
 cell or mucopolysaccaharidose patients (6) when exam and history don't
 match up
@@ -233,20 +233,20 @@ ABR by 3 months old and early intervention by 6 months old.
 Order:
 </p>
 <p>
-`<strong>`{=html}CMV`</strong>`{=html} (PCR from urine saliva or IgM if \<3weeks old)
+`<strong>CMV`</strong> (PCR from urine saliva or IgM if \<3weeks old)
 + TORCH assay
 </p>
 <p>
-`<strong>`{=html}EKG`</strong>`{=html} (r/o Jervell Lange Nielsen),
+`<strong>EKG`</strong> (r/o Jervell Lange Nielsen),
 </p>
 <p>
-`<strong>`{=html}Ophtho consult`</strong>`{=html} (see below)
+`<strong>Ophtho consult`</strong> (see below)
 </p>
 <p>
-`<strong>`{=html}Genetics testing`</strong>`{=html},
+`<strong>Genetics testing`</strong>,
 </p>
 <p>
-`<strong>`{=html}Thyroid U/S`</strong>`{=html} (multinodular goiter = Pendred's),
+`<strong>Thyroid U/S`</strong> (multinodular goiter = Pendred's),
 Percholrate test (Pendred's) isn't used anymore,
 </p>
 <p>
@@ -328,7 +328,7 @@ Facial nerve paralysis: Mobius syndrome (look for club foot, CNVI palsy), CHARGE
 </li>
 </ul>
 <h3 class="unnumbered" id="pediatric-syndromes">
-`<img alt="" src="media/image14.png" style="width:1.59792in;height:1.6375in"/>`{=html}Pediatric Syndromes
+`<img alt="" src="media/image14.png" style="width:1.59792in;height:1.6375in"/>Pediatric Syndromes
 </h3>
 <h4 class="unnumbered" id="digeorgevelocardiofacial-syndrome">
 DiGeorge/Velocardiofacial
@@ -353,7 +353,7 @@ H -- Hypoparathyroidism (low calcum)
 22q11 deletion
 </p>
 <p>
-`<strong>`{=html}15% patients have glottic webs`</strong>`{=html}. Also have medialized
+`<strong>15% patients have glottic webs`</strong>. Also have medialized
 carotids (important for tonsillectomies)
 </p>
 <h4 class="unnumbered" id="charge-syndrome">
@@ -595,16 +595,16 @@ Atresia
 </h3>
 <p>
 Workup: If newborn hearing screen on contralateral ear is ok, can
-`<u>`{=html}delay formal audiogram until 6-7 months of age`</u>`{=html} (ABR if fails on
+`<u>delay formal audiogram until 6-7 months of age`</u> (ABR if fails on
 that side)
 </p>
 <h4 class="unnumbered" id="microtia">
 Microtia
 </h4>
 <p>
-`<strong>`{=html}Grade I`</strong>`{=html}: cup or lop ear. `<strong>`{=html}Grade II`</strong>`{=html}:
-rudimentary subunits `<strong>`{=html}Grade III`</strong>`{=html}: peanut ear
-`<strong>`{=html}Grade IV`</strong>`{=html}: anotia
+`<strong>Grade I`</strong>: cup or lop ear. `<strong>Grade II`</strong>:
+rudimentary subunits `<strong>Grade III`</strong>: peanut ear
+`<strong>Grade IV`</strong>: anotia
 </p>
 <p>
 Most commonly right side, seen in men.
@@ -614,9 +614,9 @@ Ask: about teratogens (isotretinoin, thalidomide, vascular insults
 during pregnancy)
 </p>
 <p>
-Look for associated conditions: `<strong>`{=html}Goldenhar`</strong>`{=html}
+Look for associated conditions: `<strong>Goldenhar`</strong>
 (mandibular hypoplasia/hemifacial microsomia → OAV if spine defects
-noted) `<strong>`{=html}CHARGE`</strong>`{=html} (coloboma, heart defects, choanal
+noted) `<strong>CHARGE`</strong> (coloboma, heart defects, choanal
 atresia, retardation, genital hypoplasia, ear abnormalities)
 </p>
 <p>
@@ -632,23 +632,23 @@ Aural Atresia
 Associated w/ microtia in 55-90%.
 </p>
 <p>
-`<strong>`{=html}Jahrsdoerfer`</strong>`{=html} (10 total points, \>7 = candidate for
-repair) `<strong>`{=html}SOME FIRMM`</strong>`{=html}:
+`<strong>Jahrsdoerfer`</strong> (10 total points, \>7 = candidate for
+repair) `<strong>SOME FIRMM`</strong>:
 </p>
 <p>
-`<strong>`{=html}S`</strong>`{=html}tapes present (2 points), `<strong>`{=html}O`</strong>`{=html}val
-window, `<strong>`{=html}M`</strong>`{=html}iddle ear space, `<strong>`{=html}E`</strong>`{=html}xternal ear
+`<strong>S`</strong>tapes present (2 points), `<strong>O`</strong>val
+window, `<strong>M`</strong>iddle ear space, `<strong>E`</strong>xternal ear
 appearance
 </p>
 <p>
-`<strong>`{=html}F`</strong>`{=html}acial nerve, `<strong>`{=html}I`</strong>`{=html}ncus-stapes
-connection, `<strong>`{=html}R`</strong>`{=html}ound window,
-`<strong>`{=html}M`</strong>`{=html}alleus-Incus complex `<strong>`{=html}M`</strong>`{=html}astoid
+`<strong>F`</strong>acial nerve, `<strong>I`</strong>ncus-stapes
+connection, `<strong>R`</strong>ound window,
+`<strong>M`</strong>alleus-Incus complex `<strong>M`</strong>astoid
 pneumatization
 </p>
 <p>
 No need to get CT before 4 years of age. CT to evaluate for
-`<strong>`{=html}cholesteatoma`</strong>`{=html} + to assess if candidate for aural
+`<strong>cholesteatoma`</strong> + to assess if candidate for aural
 atresia repair. Aural atresia repaired AFTER microtia (because you want
 skin w/ excellent blood supply for microtia)
 </p>
@@ -657,27 +657,27 @@ PEDIATRIC NECK
 MASSES
 </h2>
 <p>
-`<strong>`{=html}History`</strong>`{=html}: Ask if mass was present at birth, growth,
+`<strong>History`</strong>: Ask if mass was present at birth, growth,
 fluctuate in size. Travel history. Pets at home (rabbits/cats). Exposure
 to farm animals (cows/pigs). B-symptoms (Fevers, chills, night sweats).
 Exposure to phenytoin (drug-induced)
 </p>
 <p>
-`<strong>`{=html}Work up`</strong>`{=html}: First determine if congenital or
+`<strong>Work up`</strong>: First determine if congenital or
 acquired
 </p>
 <blockquote>
 <p>
-`<strong>`{=html}Congenital + midline:`</strong>`{=html} thyroglossal duct cyst →
+`<strong>Congenital + midline:`</strong> thyroglossal duct cyst →
 thyroid U/S (\~1% of thyroglossal cysts are the only thyroid tissue in a
 patient)
 </p>
 <p>
-`<strong>`{=html}Congenital + lateral:`</strong>`{=html} If suspected to be branchial
+`<strong>Congenital + lateral:`</strong> If suspected to be branchial
 cleft cyst, LVM, dermoid → MRI/CT
 </p>
 <p>
-`<strong>`{=html}Acquire + infectious/inflammatory:`</strong>`{=html}
+`<strong>Acquire + infectious/inflammatory:`</strong>
 </p>
 <p>
 Get CBC, EBV, cat-scratch (Bartonella), PPD. If atypical
@@ -690,7 +690,7 @@ Brucella (cows/pigs), ACE levels (Sarcoid)
 </p>
 </blockquote>
 <p>
-`<strong>`{=html}Acquired + suspicious for malignancy (eg HL)`</strong>`{=html}:
+`<strong>Acquired + suspicious for malignancy (eg HL)`</strong>:
 consider CBC, CXR, CT and excise
 </p>
 <h3 class="unnumbered" id="congenital-neck-masses">
@@ -698,7 +698,7 @@ CONGENITAL NECK
 MASSES
 </h3>
 <p>
-`<strong>`{=html}Thyroglossal Duct cysts`</strong>`{=html}:
+`<strong>Thyroglossal Duct cysts`</strong>:
 </p>
 <ul>
 <li>
@@ -710,19 +710,19 @@ TDC will be only thyroid tissue)
 <li>
 <p>
 Excision: Sistrunk: get mid portion of hyoid and cuff of tongue
-base (see `<em>`{=html}Posterior hyoid space as related to excision of the
+base (see `<em>Posterior hyoid space as related to excision of the
 thyroglossal duct cyst. J Maddalozzo, J Alderfer, V Modi - The
-Laryngoscope, 2010`</em>`{=html})
+Laryngoscope, 2010`</em>)
 </p>
 </li>
 </ul>
 <p>
-`<strong>`{=html}Thymic cysts`</strong>`{=html}:
+`<strong>Thymic cysts`</strong>:
 </p>
 <ul>
 <li>
 <p>
-`<img alt="Type I Lateral to CN7. parallel to EAC Type 2 Medial or Lateral to CN7. More common. Ends in EAC " src="media/image15.png" style="width:1.74653in;height:1.36875in"/>`{=html}always
+`<img alt="Type I Lateral to CN7. parallel to EAC Type 2 Medial or Lateral to CN7. More common. Ends in EAC " src="media/image15.png" style="width:1.74653in;height:1.36875in"/>always
 on the left side and are cysts. Consider if patient has a macrocystic
 lymphatic malformation but no loculations (LVMs are multiple cysts,
 Thymic cysts are a single cyst). Get serial calcium and eval for
@@ -731,7 +731,7 @@ Consider DiGeorge Syndrome
 </li>
 </ul>
 <p>
-`<strong>`{=html}Congenital Torticollis (SCM tumors of infancy)`</strong>`{=html}:
+`<strong>Congenital Torticollis (SCM tumors of infancy)`</strong>:
 </p>
 <ul>
 <li>
@@ -747,7 +747,7 @@ Branchial Cleft
 Cyst
 </h4>
 <p>
-`<strong>`{=html}First Branchial Cleft Cysts`</strong>`{=html}:
+`<strong>First Branchial Cleft Cysts`</strong>:
 </p>
 <ul>
 <li>
@@ -758,7 +758,7 @@ masses. Runs along EAC. Lateral to CN7
 </li>
 <li>
 <p>
-`<img alt="" src="media/image16.png" style="width:1.53472in;height:1.37986in"/>`{=html}Type 2: 2 layers (ectoderm +
+`<img alt="" src="media/image16.png" style="width:1.53472in;height:1.37986in"/>Type 2: 2 layers (ectoderm +
 mesoderm)  More common
 </p>
 <ul>
@@ -771,7 +771,7 @@ required)
 </li>
 <li>
 <p>
-`<strong>`{=html}Second Branchial Cleft:`</strong>`{=html} Deep to CN7 (2nd arch).
+`<strong>Second Branchial Cleft:`</strong> Deep to CN7 (2nd arch).
 Superficial to CN9 (3rd arch)
 </p>
 <ul>
@@ -790,13 +790,13 @@ Treatment: Excision, may need tonsillectomy
 </li>
 <li>
 <p>
-`<strong>`{=html}Third Branchial Cleft`</strong>`{=html}: Deep to CN9 (3rdarch).
+`<strong>Third Branchial Cleft`</strong>: Deep to CN9 (3rdarch).
 Superficial to CN10. Ends in piriform
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Fourth Branchial Cleft`</strong>`{=html}: Starts by clavicle/base
+`<strong>Fourth Branchial Cleft`</strong>: Starts by clavicle/base
 of SCM → loops under subclavian or aortic arch → goes superiorly deep to
 carotids → loops around CN12 and goes to piriform sinus like 3rd
 branchial cleft cysts
@@ -837,12 +837,12 @@ of affected side)
 </ul>
 id="infectiousinflammatory-neck-masses"\>INFECTIOUS/INFLAMMATORY NECK
 <p>
-`<strong>`{=html}Viral`</strong>`{=html}: Post-infectious (especially after EBV
+`<strong>Viral`</strong>: Post-infectious (especially after EBV
 infections). EBV also helpful to r/o Postransplantation
 lymphproliferative disease (PTLD)
 </p>
 <p>
-`<strong>`{=html}Bacterial`</strong>`{=html}:
+`<strong>Bacterial`</strong>:
 </p>
 <ul>
 <li>
@@ -890,7 +890,7 @@ typically better since anti-TB drugs need to be taken for
 </li>
 </ul>
 <p>
-`<strong>`{=html}Inflammatory`</strong>`{=html}:
+`<strong>Inflammatory`</strong>:
 </p>
 <ul>
 <li>
@@ -931,7 +931,7 @@ In general: They grow at the same rate as the child, do not involute
 </li>
 </ul>
 <p>
-`<strong>`{=html}Infantile Hemangiomas`</strong>`{=html}:
+`<strong>Infantile Hemangiomas`</strong>:
 </p>
 <ul>
 <li>
@@ -964,7 +964,7 @@ Treatment: Propanolol: during proliferative phase (aka under 1yo)
 Make sure no cardiac issues and \>5weeks old: consider in-hospital if high risk (concurrent diagnoses, airway symptoms), monitor glucose.
 </li>
 <li>
-Dose: Start 0.5mg/kg/day (divided into 2-3x/day dosing). Give 1`<sup>`{=html}st`</sup>`{=html} dose in office. Monitor vitals for 2 hours and check blood sugar. Advance dose by 0.5mg/kg/dose q4days to 2 mg/kg/day as tolerated (many ppl have patients come back when increasing dose to monitor for another 2 hours). Stop after 12 month old (taper over 4 weeks). Stop if patient has illness (n/v) or wheezing from a cold. Once illness has resolved, can resume treatment
+Dose: Start 0.5mg/kg/day (divided into 2-3x/day dosing). Give 1`<sup>st`</sup> dose in office. Monitor vitals for 2 hours and check blood sugar. Advance dose by 0.5mg/kg/dose q4days to 2 mg/kg/day as tolerated (many ppl have patients come back when increasing dose to monitor for another 2 hours). Stop after 12 month old (taper over 4 weeks). Stop if patient has illness (n/v) or wheezing from a cold. Once illness has resolved, can resume treatment
 </li>
 <li>
 Superficial: can be treated with Pulse dye laser (PDL)
@@ -988,7 +988,7 @@ Non-involving (NICH): consider embolization and excision once child is school ag
 </li>
 </ul>
 <p>
-`<strong>`{=html}Kasabach-merrit dx`</strong>`{=html}:
+`<strong>Kasabach-merrit dx`</strong>:
 </p>
 <ul>
 <li>
@@ -1003,16 +1003,16 @@ LOW FLOW VASCULAR MALFORMATIONS
 </h4>
 <ul>
 <li>
-`<strong>`{=html}Capillary Malformations`</strong>`{=html}: Presents with Port-Wine stain at birth. Associated with Sturge Weber syndrome: Can involve leptomeninges- risk of seizures, mental retardation. Treatment: Pulse Dye Laser
+`<strong>Capillary Malformations`</strong>: Presents with Port-Wine stain at birth. Associated with Sturge Weber syndrome: Can involve leptomeninges- risk of seizures, mental retardation. Treatment: Pulse Dye Laser
 </li>
 <li>
-`<strong>`{=html}Venous malformations`</strong>`{=html}: Commonly on the lips. Bluish hue. Can cause consumption coagulopathy. Imaging shows calcifications (phleboliths) because of low flow. Tx Sclerotherapy
+`<strong>Venous malformations`</strong>: Commonly on the lips. Bluish hue. Can cause consumption coagulopathy. Imaging shows calcifications (phleboliths) because of low flow. Tx Sclerotherapy
 </li>
 <li>
-`<strong>`{=html}Lymphatic Malformations`</strong>`{=html}
+`<strong>Lymphatic Malformations`</strong>
 <ul>
 <li>
-Macrocystic \>2cm`<sup>`{=html}2`</sup>`{=html}. Microcystic \<2cm`<sup>`{=html}2`</sup>`{=html}
+Macrocystic \>2cm`<sup>2`</sup>. Microcystic \<2cm`<sup>2`</sup>
 </li>
 <li>
 Staging: suprahyoid worse than infrahyoid and bilateral is worse than unilateral
@@ -1083,7 +1083,7 @@ Rigid
 Bronchoscopy (Scott or Vecchiotti)
 </h3>
 <p>
-`<strong>`{=html}Set up:`</strong>`{=html}
+`<strong>Set up:`</strong>
 </p>
 <ul>
 <li>
@@ -1099,86 +1099,86 @@ On table for bronch:
 </li>
 <li>
 <p>
-`<strong>`{=html}Parson's Laryngoscope`</strong>`{=html}: Age appropriate \[see
+`<strong>Parson's Laryngoscope`</strong>: Age appropriate \[see
 chart\]
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Y-split light cable`</strong>`{=html} (must be the one with a
+`<strong>Y-split light cable`</strong> (must be the one with a
 straight light cable adapter on one side and the curved light prism for
 the laryngoscope of the other end.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Bronchoscope`</strong>`{=html} age appropriate \[check chart\]
+`<strong>Bronchoscope`</strong> age appropriate \[check chart\]
 </p>
 <ul>
 <li>
 <p>
-Connect the `<strong>`{=html}rubber nipple, suction cover, bridge, and
-light prism`</strong>`{=html} (only in half way down so it doesn't obstruct the
+Connect the `<strong>rubber nipple, suction cover, bridge, and
+light prism`</strong> (only in half way down so it doesn't obstruct the
 endoscope)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}0 degree endoscope`</strong>`{=html}: pick the largest size that
-will fit into the bronchoscope. `<strong>`{=html}MAKE SURE IT FITS`</strong>`{=html}.
-`<strong>`{=html}MAKE SURE YOU CAN SEE THROUGH IT`</strong>`{=html} (sometimes they are
+`<strong>0 degree endoscope`</strong>: pick the largest size that
+will fit into the bronchoscope. `<strong>MAKE SURE IT FITS`</strong>.
+`<strong>MAKE SURE YOU CAN SEE THROUGH IT`</strong> (sometimes they are
 broken)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}2 suctions:`</strong>`{=html} A small shorter suction for the
+`<strong>2 suctions:`</strong> A small shorter suction for the
 larynx and a longer suction (one that fits through the bronch)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Camera`</strong>`{=html}: connect to endoscope, focus and white
+`<strong>Camera`</strong>: connect to endoscope, focus and white
 balance
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Fred`</strong>`{=html}
+`<strong>Fred`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}1% lidocaine`</strong>`{=html}:
+`<strong>1% lidocaine`</strong>:
 </p>
 <ul>
 <li>
 <p>
-`<strong>`{=html}Calculate max dose for patient's weight`</strong>`{=html}: 0.4 x
+`<strong>Calculate max dose for patient's weight`</strong>: 0.4 x
 pt's weight (kg) = amount of 1% lidocaine in cc. \[eg 10kg child can have
 4cc of 1%lidocaine\]
 </p>
 </li>
 <li>
 <p>
-draw up into a `<strong>`{=html}`<u>`{=html}non-luer lock`</u>`{=html} 1cc syringe`</strong>`{=html}
-x 2. Put on a `<strong>`{=html}14G angiocath`</strong>`{=html} (orange tip)
+draw up into a `<strong>`<u>non-luer lock`</u> 1cc syringe`</strong>
+x 2. Put on a `<strong>14G angiocath`</strong> (orange tip)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Vocal fold spreader`</strong>`{=html} + `<strong>`{=html}sterile elastics +
-A right angled probe`</strong>`{=html}
+`<strong>Vocal fold spreader`</strong> + `<strong>sterile elastics +
+A right angled probe`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}A shoulder roll.`</strong>`{=html}
+`<strong>A shoulder roll.`</strong>
 </p>
 </li>
 </ul>
 <p>
-`<img alt="" src="media/image17.png" style="width:4.10216in;height:2.80449in"/>`{=html}
+`<img alt="" src="media/image17.png" style="width:4.10216in;height:2.80449in"/>
 </p>
 <p>
 []{#_Toc139824222 .anchor}Flexible
@@ -1323,8 +1323,8 @@ of trach + 2/3 sizes up).
 </li>
 <li>
 <p>
-Be in preop area `<u>`{=html}at least`</u>`{=html} 15 minutes prior to
-1`<sup>`{=html}st`</sup>`{=html} case
+Be in preop area `<u>at least`</u> 15 minutes prior to
+1`<sup>st`</sup> case
 </p>
 </li>
 <li>
@@ -1403,7 +1403,7 @@ Spatula-tip bovie on 20/20.
 </li>
 <li>
 <p>
-Suction cautery `<u>`{=html}coag on 28 (cut on 20) & blend`</u>`{=html} for
+Suction cautery `<u>coag on 28 (cut on 20) & blend`</u> for
 adenoids
 </p>
 </li>
@@ -1471,10 +1471,10 @@ PICU post-op.
 id="open-neck-cases-eg-thyroglossal-duct-cyst-vecchiotti"\>Open Neck
 Cases eg thyroglossal duct cyst (Vecchiotti)
 <p>
-Dr. Vecchiotti's glove size: `<strong>`{=html}7`</strong>`{=html}
+Dr. Vecchiotti's glove size: `<strong>7`</strong>
 </p>
 <p>
-`<u>`{=html}PREPPING - You need:`</u>`{=html}
+`<u>PREPPING - You need:`</u>
 </p>
 <ul>
 <li>
@@ -1494,11 +1494,11 @@ if young infant, ask if in doubt) .
 Have marking pen ready to pre-mark incision -- have alcohol swabs
 ready if need to erase/remark. Apply mastisol around your operative
 field. Place the 1000 drapes on all 4 sides. Do a wide prep with
-betadine. `<strong>`{=html}Put on headlight before you scrub.`</strong>`{=html} Have
+betadine. `<strong>Put on headlight before you scrub.`</strong> Have
 bipolar set on 10/10.
 </p>
 <p>
-`<u>`{=html}CLOSING -- in general:`</u>`{=html}
+`<u>CLOSING -- in general:`</u>
 </p>
 <ul>
 <li>
@@ -1528,18 +1528,18 @@ Bacitracin ointment (occasionally dermabond)
 </li>
 </ul>
 <p>
-`<strong>`{=html}Sistrunk (Thyroglossal Duct Cyst Excision)
-Technique:`</strong>`{=html} see article `<em>`{=html}Posterior Hyoid Space as Related to
-Excision of the Thyroglossal Duct Cyst`</em>`{=html} John Maddalozzo, MD, FAAP,
-FACS, Jeremy Alderfer, MD; Vikash Modi, MD `<em>`{=html}The Laryngoscope
-2010`</em>`{=html}
+`<strong>Sistrunk (Thyroglossal Duct Cyst Excision)
+Technique:`</strong> see article `<em>Posterior Hyoid Space as Related to
+Excision of the Thyroglossal Duct Cyst`</em> John Maddalozzo, MD, FAAP,
+FACS, Jeremy Alderfer, MD; Vikash Modi, MD `<em>The Laryngoscope
+2010`</em>
 </p>
 <h3 class="unnumbered" id="cochlear-implants-vecchiotti">
 Cochlear
 Implants (Vecchiotti)
 </h3>
 <p>
-`<strong>`{=html}To confirm before patient enters room`</strong>`{=html}
+`<strong>To confirm before patient enters room`</strong>
 </p>
 <ul>
 <li>
@@ -1579,11 +1579,11 @@ Corp)
 Balance the microscope. Don't drape it yet.
 </p>
 <p>
-`<img alt="" src="media/image18.jpeg" style="width:0.85278in;height:0.78194in"/>`{=html}`<img alt="" src="media/image19.png" style="width:0.9625in;height:0.71042in"/>`{=html}Call audiology and give them
+`<img alt="" src="media/image18.jpeg" style="width:0.85278in;height:0.78194in"/>`<img alt="" src="media/image19.png" style="width:0.9625in;height:0.71042in"/>Call audiology and give them
 the serial numbers for the cochlear implants
 </p>
 <p>
-`<strong>`{=html}Things to put on the non-sterile side table:`</strong>`{=html}
+`<strong>Things to put on the non-sterile side table:`</strong>
 </p>
 <p>
 M&T kit, mastisol, 1000 drapes cut in half (need 5-6), NIM
@@ -1591,10 +1591,10 @@ electrodes, tegederms cut in ½, a razor, alcohol prep pads,
 lidocaine)
 </p>
 <p>
-`<strong>`{=html}Set up`</strong>`{=html}
+`<strong>Set up`</strong>
 </p>
 <p>
-`<img alt="" src="media/image20.png" style="width:1.56319in;height:1.09306in"/>`{=html}Bed rotated 180 degrees.
+`<img alt="" src="media/image20.png" style="width:1.56319in;height:1.09306in"/>Bed rotated 180 degrees.
 Leica microscope at head of bed, tower can be on the scrub side of
 microscope, NIM monitor and suction on the scrub side by the feet.
 </p>
@@ -1609,7 +1609,7 @@ implant site.
 Draw a lazy S incision 0.5cm behind the post-auricular crease.
 </p>
 <p>
-`<img alt="" src="media/image21.png" style="width:1.94861in;height:1.71389in"/>`{=html}Place the NIM and curl the
+`<img alt="" src="media/image21.png" style="width:1.94861in;height:1.71389in"/>Place the NIM and curl the
 leads before you stick the Tegaderm down. Test the monitor. Volume to
 max, voltage at 0.8.
 </p>
@@ -1618,8 +1618,8 @@ Put mastisol where the 1000 drapes will go and put the 1000 drapes
 down.
 </p>
 <p>
-`<strong>`{=html}Evaluate the TM with the microscope before you
-prep`</strong>`{=html}.
+`<strong>Evaluate the TM with the microscope before you
+prep`</strong>.
 </p>
 <p>
 Prep a wide area. Get the parts of the 1000 drapes that slip behind
@@ -1629,7 +1629,7 @@ posterior to anterior pulling the ear forward as you do. Redraw template
 markings again. Have scrub drape the microscope and the chairs.
 </p>
 <p>
-`<strong>`{=html}Procedure`</strong>`{=html}
+`<strong>Procedure`</strong>
 </p>
 <p>
 15 blade for incision, carry down to the temporalis fascia. Raise
@@ -1641,7 +1641,7 @@ placed) down to the bone. Raise the flap with a Lempert periosteal
 elevator to the spine of henle.
 </p>
 <p>
-`<img alt="" src="media/image22.png" style="width:3.74306in;height:1.43333in"/>`{=html}Do a cortical mastoidectomy,
+`<img alt="" src="media/image22.png" style="width:3.74306in;height:1.43333in"/>Do a cortical mastoidectomy,
 focus on the corner where the tegmen and EAC meet. Use a #6 until you
 hit Koerner septum, then switch to a #3 to expose the lateral
 semicircular canal, incus buttress and the fossa incudes. The incus
@@ -1679,7 +1679,7 @@ running 4-0 vicryl. Close deep layer with 4-0 vicyrl. Superficial with a
 fluffs. Then do a mastoid dressing (with 2 kerlexs)
 </p>
 <p>
-`<strong>`{=html}Post-op Instructions`</strong>`{=html}
+`<strong>Post-op Instructions`</strong>
 </p>
 <p>
 Mastoid/glasscock dressing for 24 hours. Then glasscock dressing at
@@ -1724,9 +1724,9 @@ Usually inject 1cc or 20 units/gland
 Dr Scott's OR Guide
 </h3>
 <p>
-For `<strong>`{=html}`<u>`{=html}Andrew Scott operative note`</u>`{=html}`</strong>`{=html} you need to
-focus on FINDINGS: `<strong>`{=html}+/- submucus cleft, Size of Tonsils, Size of
-Adenoids, Electrocautery Settings.`</strong>`{=html}
+For `<strong>`<u>Andrew Scott operative note`</u>`</strong> you need to
+focus on FINDINGS: `<strong>+/- submucus cleft, Size of Tonsils, Size of
+Adenoids, Electrocautery Settings.`</strong>
 </p>
 <p>
 []{#_Toc139824229 .anchor}Adenotonsillectomy
@@ -1752,8 +1752,8 @@ palate
 </li>
 <li>
 <p>
-Place soft suction catheter through nasal cavity; `<u>`{=html}place rolled
-gauze between soft suction catheter and clamp to secure in place`</u>`{=html}
+Place soft suction catheter through nasal cavity; `<u>place rolled
+gauze between soft suction catheter and clamp to secure in place`</u>
 (Vecchiotti does not use rolled gauze)
 </p>
 </li>
@@ -1856,11 +1856,11 @@ Tonsillectomy
 Patients
 </h4>
 <p>
-`<strong>`{=html}Orders`</strong>`{=html}: IVF, soft diet, pulse oximetry, cool
+`<strong>Orders`</strong>: IVF, soft diet, pulse oximetry, cool
 humidified air, ice pack to back of neck,
 </p>
 <p>
-`<strong>`{=html}Meds`</strong>`{=html}:
+`<strong>Meds`</strong>:
 </p>
 <p>
 Tylenol & ibuprofen liquid PO (should be standing orders, to be
@@ -1874,7 +1874,7 @@ patients \<6yo)
 Zofran IV, +/- Phenergine PR
 </p>
 <p>
-`<strong>`{=html}D/C Criteria`</strong>`{=html}: When you check soarian in the AM of
+`<strong>D/C Criteria`</strong>: When you check soarian in the AM of
 POD#1: make sure
 </p>
 <p>
@@ -1891,16 +1891,16 @@ Mandibular
 Distraction
 </h4>
 <p>
-POD#0-1: stay intubated. IV ancef or vanco. `<strong>`{=html}Trend cap
-gas`</strong>`{=html} (high risk of ↑↑PCO`<sub>`{=html}2`</sub>`{=html}) POD#2: clean pins w/ H2O2
+POD#0-1: stay intubated. IV ancef or vanco. `<strong>Trend cap
+gas`</strong> (high risk of ↑↑PCO`<sub>2`</sub>) POD#2: clean pins w/ H2O2
 and distraction begins.
 </p>
 <p>
-`<strong>`{=html}External devices:`</strong>`{=html} 1.5 turns (0.75mm) BID (
+`<strong>External devices:`</strong> 1.5 turns (0.75mm) BID (
 1.5mm/day)
 </p>
 <p>
-`<strong>`{=html}Internal devices:`</strong>`{=html} 1 turn (1mm) BID (2mm/day)
+`<strong>Internal devices:`</strong> 1 turn (1mm) BID (2mm/day)
 </p>
 <p>
 POD#5: wean sedation POD#6: extubate, dispo planning. Discharge on
@@ -1917,9 +1917,9 @@ POD#0-5: Make sure patient is on zosyn. Check for pressure necrosis
 (occiput, heels), and alar necrosis.
 </p>
 <p>
-`<strong>`{=html}Periextubation plan (POD#5):`</strong>`{=html} Decadron 0.25-0.5mg/kg
+`<strong>Periextubation plan (POD#5):`</strong> Decadron 0.25-0.5mg/kg
 to be given 13 hours prior to extubation q6hrs x3 so last dose is 1 hour
-prior to extubation. `<u>`{=html}Propofol "washout":`</u>`{=html} 8-10 hours prior to
+prior to extubation. `<u>Propofol "washout":`</u> 8-10 hours prior to
 planned extubation: start propofol 30mcg/kg/min (can titrate up to max
 100mcg/kg/min) then after 1 hour, can cut opioid and benzodiazepine
 infusions to 25-50% of previous level. continue precedex at same rate.
@@ -1947,12 +1947,12 @@ Glasscock x 24 hours then at night prn comfort
 <p>
 Ciprodex & Bactroban: Remove the cotton ball in ear, apply 3
 drops of ciprodex, then placed a new cotton ball coated in Bactroban
-back into the ear. Do this `<u>`{=html}three times a day`</u>`{=html}
+back into the ear. Do this `<u>three times a day`</u>
 </p>
 </li>
 <li>
 <p>
-`<u>`{=html}Sinus`</u>`{=html} precautions and `<u>`{=html}dry ear`</u>`{=html} precautions x 2
+`<u>Sinus`</u> precautions and `<u>dry ear`</u> precautions x 2
 weeks
 </p>
 </li>
@@ -1972,7 +1972,7 @@ Scott Cleft Lip
 & Cleft Palate
 </h4>
 <p>
-`<strong>`{=html}Medications`</strong>`{=html}:
+`<strong>Medications`</strong>:
 </p>
 <ul>
 <li>
@@ -2003,7 +2003,7 @@ LR @ mIVF rate
 <li>
 <p>
 Nasal saline spray: 4 drops to each nostril and to lip incisions
-q4 hours `<strong>`{=html}`<u>`{=html}\[cleft lip only\]`</u>`{=html}`</strong>`{=html} (this is super
+q4 hours `<strong>`<u>\[cleft lip only\]`</u>`</strong> (this is super
 important -- write an RN order to clean nose with q-tip if there is any
 crusting and do this on rounds in the AM)
 </p>
@@ -2016,7 +2016,7 @@ patients)
 </li>
 </ul>
 <p>
-`<strong>`{=html}Non-Medication Orders`</strong>`{=html}:
+`<strong>Non-Medication Orders`</strong>:
 </p>
 <ul>
 <li>
@@ -2031,21 +2031,21 @@ Activity ad lib
 </li>
 <li>
 <p>
-Regular Pedi Age-appropriate diet `<strong>`{=html}`<u>`{=html}\[cleft
-lip\]`</u>`{=html}`</strong>`{=html}
+Regular Pedi Age-appropriate diet `<strong>`<u>\[cleft
+lip\]`</u>`</strong>
 </p>
 </li>
 <li>
 <p>
-Soft/Pureed diet until follow up `<strong>`{=html}`<u>`{=html}\[cleft
-palate\]`</u>`{=html}`</strong>`{=html}
+Soft/Pureed diet until follow up `<strong>`<u>\[cleft
+palate\]`</u>`</strong>
 </p>
 </li>
 <li>
 <p>
 Welcome sleeves at all times (except under direct supervision) x2
-weeks (`<em>`{=html}sign the restraint order form in PACU otherwise you WILL get
-a page at night)`</em>`{=html}
+weeks (`<em>sign the restraint order form in PACU otherwise you WILL get
+a page at night)`</em>
 </p>
 </li>
 <li>
@@ -2092,12 +2092,12 @@ No ointment of any kind to incisions
 </li>
 <li>
 <p>
-`<u>`{=html}Follow up is 3 weeks`</u>`{=html}
+`<u>Follow up is 3 weeks`</u>
 </p>
 </li>
 </ul>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/pediatric-otolaryngology/clinic-guide.md
+++ b/pediatric-otolaryngology/clinic-guide.md
@@ -92,22 +92,22 @@ Family hx of ear disease; ankyloglossia (paternal);
 Pediatric ROS
 </h4>
 <p>
-`<strong>`{=html}Ears: No`</strong>`{=html} episodes of AOM. No otorrhea or otalgia. No
+`<strong>Ears: No`</strong> episodes of AOM. No otorrhea or otalgia. No
 concerns for hearing loss. No difficulty with balance. No history of
 speech delay.
 </p>
 <p>
-`<strong>`{=html}Nose`</strong>`{=html}: Denies chronic nasal congestion or rhinorrhea.
+`<strong>Nose`</strong>: Denies chronic nasal congestion or rhinorrhea.
 No epistaxis. No history or symptoms of environmental allergies; no
 formal allergy evaluation to date.
 </p>
 <p>
-`<strong>`{=html}Throat`</strong>`{=html}: No snoring or mouth breathing at night. No
+`<strong>Throat`</strong>: No snoring or mouth breathing at night. No
 witnessed apneic pauses in breathing while sleeping. No nighttime
 enuresis. No episodes of tonsillitis or frequent sore throats.
 </p>
 <p>
-`<strong>`{=html}Airway`</strong>`{=html}: No dysphagia or odynophagia. Denies any
+`<strong>Airway`</strong>: No dysphagia or odynophagia. Denies any
 change in sound of voice or cry, no hoarseness. No gasping or choking
 spells. No episodes of respiratory distress. (Stridor/how's the
 patient's cry, choking w. food/hx of respiration PNA, weight loss/FTT,
@@ -118,35 +118,35 @@ OME -
 Clinical Practice Guidelines
 </h3>
 <p>
-`<strong>`{=html}Recurrent AOM:`</strong>`{=html} 3 discrete episodes of AOM in 6months
+`<strong>Recurrent AOM:`</strong> 3 discrete episodes of AOM in 6months
 or 4 in past 12 months
 </p>
 <p>
-`<strong>`{=html}Chronic OME`</strong>`{=html}: OME that persists for 3+ months
+`<strong>Chronic OME`</strong>: OME that persists for 3+ months
 </p>
 <p>
 Always use pneumatic otoscopy. Tympanometry if diagnosis is
 uncertain. Council parents of newborns who fail NBHS of importance of
 f/u due to risk of SNHL. Should screen of OME in at-risk patients.
-`<strong>`{=html}Watchful waiting recommended for`</strong>`{=html} c`<strong>`{=html}hild with OME
-w/o risk factors.`</strong>`{=html} Don't give steroids, antihistamines, or
-decongestants to childrens with OME. `<strong>`{=html}OME \>3months -- get
-audiogram`</strong>`{=html}. Re-eval patients with OME q3-6months until OME no
+`<strong>Watchful waiting recommended for`</strong> c`<strong>hild with OME
+w/o risk factors.`</strong> Don't give steroids, antihistamines, or
+decongestants to childrens with OME. `<strong>OME \>3months -- get
+audiogram`</strong>. Re-eval patients with OME q3-6months until OME no
 longer present or hearing loss identified (yes, repeat hearing test
 q3-6months) or structural abnormalities/middle ear disease suspected.
-`<strong>`{=html}Chronic OME + hearing loss or symptoms that are consistent w/
-hearing loss`</strong>`{=html} -- book for tympanostomy tube placement.
-`<strong>`{=html}Recurrent AOM`</strong>`{=html}: book for tympanostomy tube placement if
-OME seen on day of visit. `<strong>`{=html}Patients \>4yo should get an
-adenoidectomy with ear tubes.`</strong>`{=html}
+`<strong>Chronic OME + hearing loss or symptoms that are consistent w/
+hearing loss`</strong> -- book for tympanostomy tube placement.
+`<strong>Recurrent AOM`</strong>: book for tympanostomy tube placement if
+OME seen on day of visit. `<strong>Patients \>4yo should get an
+adenoidectomy with ear tubes.`</strong>
 </p>
 <p>
-`<strong>`{=html}SRBD/OSA`</strong>`{=html}
+`<strong>SRBD/OSA`</strong>
 </p>
 <ul>
 <li>
 <p>
-Obtain PSG if: (1) obese \>95`<sup>`{=html}th`</sup>`{=html} %ile (2) down
+Obtain PSG if: (1) obese \>95`<sup>th`</sup> %ile (2) down
 syndrome (3) craniofacial disorder (4) neuromuscular disorder (5) sickle
 cell or mucopolysaccaharidose patients (6) when exam and history don't
 match up
@@ -233,20 +233,20 @@ ABR by 3 months old and early intervention by 6 months old.
 Order:
 </p>
 <p>
-`<strong>`{=html}CMV`</strong>`{=html} (PCR from urine saliva or IgM if \<3weeks old)
+`<strong>CMV`</strong> (PCR from urine saliva or IgM if \<3weeks old)
 + TORCH assay
 </p>
 <p>
-`<strong>`{=html}EKG`</strong>`{=html} (r/o Jervell Lange Nielsen),
+`<strong>EKG`</strong> (r/o Jervell Lange Nielsen),
 </p>
 <p>
-`<strong>`{=html}Ophtho consult`</strong>`{=html} (see below)
+`<strong>Ophtho consult`</strong> (see below)
 </p>
 <p>
-`<strong>`{=html}Genetics testing`</strong>`{=html},
+`<strong>Genetics testing`</strong>,
 </p>
 <p>
-`<strong>`{=html}Thyroid U/S`</strong>`{=html} (multinodular goiter = Pendred's),
+`<strong>Thyroid U/S`</strong> (multinodular goiter = Pendred's),
 Percholrate test (Pendred's) isn't used anymore,
 </p>
 <p>
@@ -328,7 +328,7 @@ Facial nerve paralysis: Mobius syndrome (look for club foot, CNVI palsy), CHARGE
 </li>
 </ul>
 <h3 class="unnumbered" id="pediatric-syndromes">
-`<img alt="" src="../media/image14.png" style="width:1.59792in;height:1.6375in"/>`{=html}Pediatric Syndromes
+`<img alt="" src="../media/image14.png" style="width:1.59792in;height:1.6375in"/>Pediatric Syndromes
 </h3>
 <h4 class="unnumbered" id="digeorgevelocardiofacial-syndrome">
 DiGeorge/Velocardiofacial
@@ -353,7 +353,7 @@ H -- Hypoparathyroidism (low calcum)
 22q11 deletion
 </p>
 <p>
-`<strong>`{=html}15% patients have glottic webs`</strong>`{=html}. Also have medialized
+`<strong>15% patients have glottic webs`</strong>. Also have medialized
 carotids (important for tonsillectomies)
 </p>
 <h4 class="unnumbered" id="charge-syndrome">
@@ -595,14 +595,14 @@ Atresia
 </h3>
 <p>
 Workup: If newborn hearing screen on contralateral ear is ok, can
-`<u>`{=html}delay formal audiogram until 6-7 months of age`</u>`{=html} (ABR if fails on
+`<u>delay formal audiogram until 6-7 months of age`</u> (ABR if fails on
 <h4 class="unnumbered" id="microtia">
 Microtia
 </h4>
 <p>
-`<strong>`{=html}Grade I`</strong>`{=html}: cup or lop ear. `<strong>`{=html}Grade II`</strong>`{=html}:
-rudimentary subunits `<strong>`{=html}Grade III`</strong>`{=html}: peanut ear
-`<strong>`{=html}Grade IV`</strong>`{=html}: anotia
+`<strong>Grade I`</strong>: cup or lop ear. `<strong>Grade II`</strong>:
+rudimentary subunits `<strong>Grade III`</strong>: peanut ear
+`<strong>Grade IV`</strong>: anotia
 </p>
 <p>
 Most commonly right side, seen in men.
@@ -612,9 +612,9 @@ Ask: about teratogens (isotretinoin, thalidomide, vascular insults
 during pregnancy)
 </p>
 <p>
-Look for associated conditions: `<strong>`{=html}Goldenhar`</strong>`{=html}
+Look for associated conditions: `<strong>Goldenhar`</strong>
 (mandibular hypoplasia/hemifacial microsomia → OAV if spine defects
-noted) `<strong>`{=html}CHARGE`</strong>`{=html} (coloboma, heart defects, choanal
+noted) `<strong>CHARGE`</strong> (coloboma, heart defects, choanal
 atresia, retardation, genital hypoplasia, ear abnormalities)
 </p>
 <p>
@@ -629,28 +629,28 @@ Aural Atresia
 Associated w/ microtia in 55-90%.
 </p>
 <p>
-`<strong>`{=html}Jahrsdoerfer`</strong>`{=html} (10 total points, \>7 = candidate for
-repair) `<strong>`{=html}SOME FIRMM`</strong>`{=html}:
+`<strong>Jahrsdoerfer`</strong> (10 total points, \>7 = candidate for
+repair) `<strong>SOME FIRMM`</strong>:
 </p>
 <p>
-`<strong>`{=html}S`</strong>`{=html}tapes present (2 points), `<strong>`{=html}O`</strong>`{=html}val
-window, `<strong>`{=html}M`</strong>`{=html}iddle ear space, `<strong>`{=html}E`</strong>`{=html}xternal ear
+`<strong>S`</strong>tapes present (2 points), `<strong>O`</strong>val
+window, `<strong>M`</strong>iddle ear space, `<strong>E`</strong>xternal ear
 appearance
 </p>
 <p>
-`<strong>`{=html}F`</strong>`{=html}acial nerve, `<strong>`{=html}I`</strong>`{=html}ncus-stapes
-connection, `<strong>`{=html}R`</strong>`{=html}ound window,
-`<strong>`{=html}M`</strong>`{=html}alleus-Incus complex `<strong>`{=html}M`</strong>`{=html}astoid
+`<strong>F`</strong>acial nerve, `<strong>I`</strong>ncus-stapes
+connection, `<strong>R`</strong>ound window,
+`<strong>M`</strong>alleus-Incus complex `<strong>M`</strong>astoid
 pneumatization
 </p>
 <p>
 No need to get CT before 4 years of age. CT to evaluate for
-`<strong>`{=html}cholesteatoma`</strong>`{=html} + to assess if candidate for aural
+`<strong>cholesteatoma`</strong> + to assess if candidate for aural
 atresia repair. Aural atresia repaired AFTER microtia (because you want
 skin w/ excellent blood supply for microtia)
 </p>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/pediatric-otolaryngology/index.md
+++ b/pediatric-otolaryngology/index.md
@@ -4,12 +4,12 @@ title: Pediatric Otolaryngology
 ---
 <ul>
 <li>
-`<a href="clinic-guide.html">`{=html}Clinic Guide`</a>`{=html}
+`<a href="clinic-guide.html">Clinic Guide`</a>
 </li>
 <li>
-`<a href="neck-masses.html">`{=html}Neck Masses`</a>`{=html}
+`<a href="neck-masses.html">Neck Masses`</a>
 </li>
 <li>
-`<a href="or-guide.html">`{=html}OR Guide`</a>`{=html}
+`<a href="or-guide.html">OR Guide`</a>
 </li>
 </ul>

--- a/pediatric-otolaryngology/neck-masses.md
+++ b/pediatric-otolaryngology/neck-masses.md
@@ -7,27 +7,27 @@ PEDIATRIC NECK
 MASSES
 </h2>
 <p>
-`<strong>`{=html}History`</strong>`{=html}: Ask if mass was present at birth, growth,
+`<strong>History`</strong>: Ask if mass was present at birth, growth,
 fluctuate in size. Travel history. Pets at home (rabbits/cats). Exposure
 to farm animals (cows/pigs). B-symptoms (Fevers, chills, night sweats).
 Exposure to phenytoin (drug-induced)
 </p>
 <p>
-`<strong>`{=html}Work up`</strong>`{=html}: First determine if congenital or
+`<strong>Work up`</strong>: First determine if congenital or
 acquired
 </p>
 <blockquote>
 <p>
-`<strong>`{=html}Congenital + midline:`</strong>`{=html} thyroglossal duct cyst →
+`<strong>Congenital + midline:`</strong> thyroglossal duct cyst →
 thyroid U/S (\~1% of thyroglossal cysts are the only thyroid tissue in a
 patient)
 </p>
 <p>
-`<strong>`{=html}Congenital + lateral:`</strong>`{=html} If suspected to be branchial
+`<strong>Congenital + lateral:`</strong> If suspected to be branchial
 cleft cyst, LVM, dermoid → MRI/CT
 </p>
 <p>
-`<strong>`{=html}Acquire + infectious/inflammatory:`</strong>`{=html}
+`<strong>Acquire + infectious/inflammatory:`</strong>
 </p>
 <p>
 Get CBC, EBV, cat-scratch (Bartonella), PPD. If atypical
@@ -40,7 +40,7 @@ Brucella (cows/pigs), ACE levels (Sarcoid)
 </p>
 </blockquote>
 <p>
-`<strong>`{=html}Acquired + suspicious for malignancy (eg HL)`</strong>`{=html}:
+`<strong>Acquired + suspicious for malignancy (eg HL)`</strong>:
 consider CBC, CXR, CT and excise
 </p>
 <h3 class="unnumbered" id="congenital-neck-masses">
@@ -48,7 +48,7 @@ CONGENITAL NECK
 MASSES
 </h3>
 <p>
-`<strong>`{=html}Thyroglossal Duct cysts`</strong>`{=html}:
+`<strong>Thyroglossal Duct cysts`</strong>:
 </p>
 <ul>
 <li>
@@ -60,19 +60,19 @@ TDC will be only thyroid tissue)
 <li>
 <p>
 Excision: Sistrunk: get mid portion of hyoid and cuff of tongue
-base (see `<em>`{=html}Posterior hyoid space as related to excision of the
+base (see `<em>Posterior hyoid space as related to excision of the
 thyroglossal duct cyst. J Maddalozzo, J Alderfer, V Modi - The
-Laryngoscope, 2010`</em>`{=html})
+Laryngoscope, 2010`</em>)
 </p>
 </li>
 </ul>
 <p>
-`<strong>`{=html}Thymic cysts`</strong>`{=html}:
+`<strong>Thymic cysts`</strong>:
 </p>
 <ul>
 <li>
 <p>
-`<img alt="Type I Lateral to CN7. parallel to EAC Type 2 Medial or Lateral to CN7. More common. Ends in EAC " src="../media/image15.png" style="width:1.74653in;height:1.36875in"/>`{=html}always
+`<img alt="Type I Lateral to CN7. parallel to EAC Type 2 Medial or Lateral to CN7. More common. Ends in EAC " src="../media/image15.png" style="width:1.74653in;height:1.36875in"/>always
 on the left side and are cysts. Consider if patient has a macrocystic
 lymphatic malformation but no loculations (LVMs are multiple cysts,
 Thymic cysts are a single cyst). Get serial calcium and eval for
@@ -81,7 +81,7 @@ Consider DiGeorge Syndrome
 </li>
 </ul>
 <p>
-`<strong>`{=html}Congenital Torticollis (SCM tumors of infancy)`</strong>`{=html}:
+`<strong>Congenital Torticollis (SCM tumors of infancy)`</strong>:
 </p>
 <ul>
 <li>
@@ -97,7 +97,7 @@ Branchial Cleft
 Cyst
 </h4>
 <p>
-`<strong>`{=html}First Branchial Cleft Cysts`</strong>`{=html}:
+`<strong>First Branchial Cleft Cysts`</strong>:
 </p>
 <ul>
 <li>
@@ -108,7 +108,7 @@ masses. Runs along EAC. Lateral to CN7
 </li>
 <li>
 <p>
-`<img alt="" src="../media/image16.png" style="width:1.53472in;height:1.37986in"/>`{=html}Type 2: 2 layers (ectoderm +
+`<img alt="" src="../media/image16.png" style="width:1.53472in;height:1.37986in"/>Type 2: 2 layers (ectoderm +
 mesoderm)  More common
 </p>
 <ul>
@@ -121,7 +121,7 @@ required)
 </li>
 <li>
 <p>
-`<strong>`{=html}Second Branchial Cleft:`</strong>`{=html} Deep to CN7 (2nd arch).
+`<strong>Second Branchial Cleft:`</strong> Deep to CN7 (2nd arch).
 Superficial to CN9 (3rd arch)
 </p>
 <ul>
@@ -140,13 +140,13 @@ Treatment: Excision, may need tonsillectomy
 </li>
 <li>
 <p>
-`<strong>`{=html}Third Branchial Cleft`</strong>`{=html}: Deep to CN9 (3rdarch).
+`<strong>Third Branchial Cleft`</strong>: Deep to CN9 (3rdarch).
 Superficial to CN10. Ends in piriform
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Fourth Branchial Cleft`</strong>`{=html}: Starts by clavicle/base
+`<strong>Fourth Branchial Cleft`</strong>: Starts by clavicle/base
 of SCM → loops under subclavian or aortic arch → goes superiorly deep to
 carotids → loops around CN12 and goes to piriform sinus like 3rd
 branchial cleft cysts
@@ -187,12 +187,12 @@ of affected side)
 </ul>
 id="infectiousinflammatory-neck-masses"\>INFECTIOUS/INFLAMMATORY NECK
 <p>
-`<strong>`{=html}Viral`</strong>`{=html}: Post-infectious (especially after EBV
+`<strong>Viral`</strong>: Post-infectious (especially after EBV
 infections). EBV also helpful to r/o Postransplantation
 lymphproliferative disease (PTLD)
 </p>
 <p>
-`<strong>`{=html}Bacterial`</strong>`{=html}:
+`<strong>Bacterial`</strong>:
 </p>
 <ul>
 <li>
@@ -240,7 +240,7 @@ typically better since anti-TB drugs need to be taken for
 </li>
 </ul>
 <p>
-`<strong>`{=html}Inflammatory`</strong>`{=html}:
+`<strong>Inflammatory`</strong>:
 </p>
 <ul>
 <li>
@@ -281,7 +281,7 @@ In general: They grow at the same rate as the child, do not involute
 </li>
 </ul>
 <p>
-`<strong>`{=html}Infantile Hemangiomas`</strong>`{=html}:
+`<strong>Infantile Hemangiomas`</strong>:
 </p>
 <ul>
 <li>
@@ -314,7 +314,7 @@ Treatment: Propanolol: during proliferative phase (aka under 1yo)
 Make sure no cardiac issues and \>5weeks old: consider in-hospital if high risk (concurrent diagnoses, airway symptoms), monitor glucose.
 </li>
 <li>
-Dose: Start 0.5mg/kg/day (divided into 2-3x/day dosing). Give 1`<sup>`{=html}st`</sup>`{=html} dose in office. Monitor vitals for 2 hours and check blood sugar. Advance dose by 0.5mg/kg/dose q4days to 2 mg/kg/day as tolerated (many ppl have patients come back when increasing dose to monitor for another 2 hours). Stop after 12 month old (taper over 4 weeks). Stop if patient has illness (n/v) or wheezing from a cold. Once illness has resolved, can resume treatment
+Dose: Start 0.5mg/kg/day (divided into 2-3x/day dosing). Give 1`<sup>st`</sup> dose in office. Monitor vitals for 2 hours and check blood sugar. Advance dose by 0.5mg/kg/dose q4days to 2 mg/kg/day as tolerated (many ppl have patients come back when increasing dose to monitor for another 2 hours). Stop after 12 month old (taper over 4 weeks). Stop if patient has illness (n/v) or wheezing from a cold. Once illness has resolved, can resume treatment
 </li>
 <li>
 Superficial: can be treated with Pulse dye laser (PDL)
@@ -338,7 +338,7 @@ Non-involving (NICH): consider embolization and excision once child is school ag
 </li>
 </ul>
 <p>
-`<strong>`{=html}Kasabach-merrit dx`</strong>`{=html}:
+`<strong>Kasabach-merrit dx`</strong>:
 </p>
 <ul>
 <li>
@@ -353,16 +353,16 @@ LOW FLOW VASCULAR MALFORMATIONS
 </h4>
 <ul>
 <li>
-`<strong>`{=html}Capillary Malformations`</strong>`{=html}: Presents with Port-Wine stain at birth. Associated with Sturge Weber syndrome: Can involve leptomeninges- risk of seizures, mental retardation. Treatment: Pulse Dye Laser
+`<strong>Capillary Malformations`</strong>: Presents with Port-Wine stain at birth. Associated with Sturge Weber syndrome: Can involve leptomeninges- risk of seizures, mental retardation. Treatment: Pulse Dye Laser
 </li>
 <li>
-`<strong>`{=html}Venous malformations`</strong>`{=html}: Commonly on the lips. Bluish hue. Can cause consumption coagulopathy. Imaging shows calcifications (phleboliths) because of low flow. Tx Sclerotherapy
+`<strong>Venous malformations`</strong>: Commonly on the lips. Bluish hue. Can cause consumption coagulopathy. Imaging shows calcifications (phleboliths) because of low flow. Tx Sclerotherapy
 </li>
 <li>
-`<strong>`{=html}Lymphatic Malformations`</strong>`{=html}
+`<strong>Lymphatic Malformations`</strong>
 <ul>
 <li>
-Macrocystic \>2cm`<sup>`{=html}2`</sup>`{=html}. Microcystic \<2cm`<sup>`{=html}2`</sup>`{=html}
+Macrocystic \>2cm`<sup>2`</sup>. Microcystic \<2cm`<sup>2`</sup>
 </li>
 <li>
 Staging: suprahyoid worse than infrahyoid and bilateral is worse than unilateral
@@ -425,7 +425,7 @@ Lymphoma: Hogkins is more common than NHL in the neck: HL = B-symptoms
 </li>
 </ul>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/pediatric-otolaryngology/or-guide.md
+++ b/pediatric-otolaryngology/or-guide.md
@@ -11,7 +11,7 @@ Rigid
 Bronchoscopy (Scott or Vecchiotti)
 </h3>
 <p>
-`<strong>`{=html}Set up:`</strong>`{=html}
+`<strong>Set up:`</strong>
 </p>
 <ul>
 <li>
@@ -27,86 +27,86 @@ On table for bronch:
 </li>
 <li>
 <p>
-`<strong>`{=html}Parson's Laryngoscope`</strong>`{=html}: Age appropriate \[see
+`<strong>Parson's Laryngoscope`</strong>: Age appropriate \[see
 chart\]
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Y-split light cable`</strong>`{=html} (must be the one with a
+`<strong>Y-split light cable`</strong> (must be the one with a
 straight light cable adapter on one side and the curved light prism for
 the laryngoscope of the other end.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Bronchoscope`</strong>`{=html} age appropriate \[check chart\]
+`<strong>Bronchoscope`</strong> age appropriate \[check chart\]
 </p>
 <ul>
 <li>
 <p>
-Connect the `<strong>`{=html}rubber nipple, suction cover, bridge, and
-light prism`</strong>`{=html} (only in half way down so it doesn't obstruct the
+Connect the `<strong>rubber nipple, suction cover, bridge, and
+light prism`</strong> (only in half way down so it doesn't obstruct the
 endoscope)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}0 degree endoscope`</strong>`{=html}: pick the largest size that
-will fit into the bronchoscope. `<strong>`{=html}MAKE SURE IT FITS`</strong>`{=html}.
-`<strong>`{=html}MAKE SURE YOU CAN SEE THROUGH IT`</strong>`{=html} (sometimes they are
+`<strong>0 degree endoscope`</strong>: pick the largest size that
+will fit into the bronchoscope. `<strong>MAKE SURE IT FITS`</strong>.
+`<strong>MAKE SURE YOU CAN SEE THROUGH IT`</strong> (sometimes they are
 broken)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}2 suctions:`</strong>`{=html} A small shorter suction for the
+`<strong>2 suctions:`</strong> A small shorter suction for the
 larynx and a longer suction (one that fits through the bronch)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Camera`</strong>`{=html}: connect to endoscope, focus and white
+`<strong>Camera`</strong>: connect to endoscope, focus and white
 balance
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Fred`</strong>`{=html}
+`<strong>Fred`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}1% lidocaine`</strong>`{=html}:
+`<strong>1% lidocaine`</strong>:
 </p>
 <ul>
 <li>
 <p>
-`<strong>`{=html}Calculate max dose for patient's weight`</strong>`{=html}: 0.4 x
+`<strong>Calculate max dose for patient's weight`</strong>: 0.4 x
 pt's weight (kg) = amount of 1% lidocaine in cc. \[eg 10kg child can have
 4cc of 1%lidocaine\]
 </p>
 </li>
 <li>
 <p>
-draw up into a `<strong>`{=html}`<u>`{=html}non-luer lock`</u>`{=html} 1cc syringe`</strong>`{=html}
-x 2. Put on a `<strong>`{=html}14G angiocath`</strong>`{=html} (orange tip)
+draw up into a `<strong>`<u>non-luer lock`</u> 1cc syringe`</strong>
+x 2. Put on a `<strong>14G angiocath`</strong> (orange tip)
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}Vocal fold spreader`</strong>`{=html} + `<strong>`{=html}sterile elastics +
-A right angled probe`</strong>`{=html}
+`<strong>Vocal fold spreader`</strong> + `<strong>sterile elastics +
+A right angled probe`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}A shoulder roll.`</strong>`{=html}
+`<strong>A shoulder roll.`</strong>
 </p>
 </li>
 </ul>
 <p>
-`<img alt="" src="../media/image17.png" style="width:4.10216in;height:2.80449in"/>`{=html}
+`<img alt="" src="../media/image17.png" style="width:4.10216in;height:2.80449in"/>
 </p>
 <p>
 []{#_Toc139824222 .anchor}Flexible
@@ -251,8 +251,8 @@ of trach + 2/3 sizes up).
 </li>
 <li>
 <p>
-Be in preop area `<u>`{=html}at least`</u>`{=html} 15 minutes prior to
-1`<sup>`{=html}st`</sup>`{=html} case
+Be in preop area `<u>at least`</u> 15 minutes prior to
+1`<sup>st`</sup> case
 </p>
 </li>
 <li>
@@ -331,7 +331,7 @@ Spatula-tip bovie on 20/20.
 </li>
 <li>
 <p>
-Suction cautery `<u>`{=html}coag on 28 (cut on 20) & blend`</u>`{=html} for
+Suction cautery `<u>coag on 28 (cut on 20) & blend`</u> for
 adenoids
 </p>
 </li>
@@ -399,10 +399,10 @@ PICU post-op.
 id="open-neck-cases-eg-thyroglossal-duct-cyst-vecchiotti"\>Open Neck
 Cases eg thyroglossal duct cyst (Vecchiotti)
 <p>
-Dr. Vecchiotti's glove size: `<strong>`{=html}7`</strong>`{=html}
+Dr. Vecchiotti's glove size: `<strong>7`</strong>
 </p>
 <p>
-`<u>`{=html}PREPPING - You need:`</u>`{=html}
+`<u>PREPPING - You need:`</u>
 </p>
 <ul>
 <li>
@@ -422,11 +422,11 @@ if young infant, ask if in doubt) .
 Have marking pen ready to pre-mark incision -- have alcohol swabs
 ready if need to erase/remark. Apply mastisol around your operative
 field. Place the 1000 drapes on all 4 sides. Do a wide prep with
-betadine. `<strong>`{=html}Put on headlight before you scrub.`</strong>`{=html} Have
+betadine. `<strong>Put on headlight before you scrub.`</strong> Have
 bipolar set on 10/10.
 </p>
 <p>
-`<u>`{=html}CLOSING -- in general:`</u>`{=html}
+`<u>CLOSING -- in general:`</u>
 </p>
 <ul>
 <li>
@@ -456,18 +456,18 @@ Bacitracin ointment (occasionally dermabond)
 </li>
 </ul>
 <p>
-`<strong>`{=html}Sistrunk (Thyroglossal Duct Cyst Excision)
-Technique:`</strong>`{=html} see article `<em>`{=html}Posterior Hyoid Space as Related to
-Excision of the Thyroglossal Duct Cyst`</em>`{=html} John Maddalozzo, MD, FAAP,
-FACS, Jeremy Alderfer, MD; Vikash Modi, MD `<em>`{=html}The Laryngoscope
-2010`</em>`{=html}
+`<strong>Sistrunk (Thyroglossal Duct Cyst Excision)
+Technique:`</strong> see article `<em>Posterior Hyoid Space as Related to
+Excision of the Thyroglossal Duct Cyst`</em> John Maddalozzo, MD, FAAP,
+FACS, Jeremy Alderfer, MD; Vikash Modi, MD `<em>The Laryngoscope
+2010`</em>
 </p>
 <h3 class="unnumbered" id="cochlear-implants-vecchiotti">
 Cochlear
 Implants (Vecchiotti)
 </h3>
 <p>
-`<strong>`{=html}To confirm before patient enters room`</strong>`{=html}
+`<strong>To confirm before patient enters room`</strong>
 </p>
 <ul>
 <li>
@@ -507,11 +507,11 @@ Corp)
 Balance the microscope. Don't drape it yet.
 </p>
 <p>
-`<img alt="" src="../media/image18.jpeg" style="width:0.85278in;height:0.78194in"/>`{=html}`<img alt="" src="../media/image19.png" style="width:0.9625in;height:0.71042in"/>`{=html}Call audiology and give them
+`<img alt="" src="../media/image18.jpeg" style="width:0.85278in;height:0.78194in"/>`<img alt="" src="../media/image19.png" style="width:0.9625in;height:0.71042in"/>Call audiology and give them
 the serial numbers for the cochlear implants
 </p>
 <p>
-`<strong>`{=html}Things to put on the non-sterile side table:`</strong>`{=html}
+`<strong>Things to put on the non-sterile side table:`</strong>
 </p>
 <p>
 M&T kit, mastisol, 1000 drapes cut in half (need 5-6), NIM
@@ -519,10 +519,10 @@ electrodes, tegederms cut in ½, a razor, alcohol prep pads,
 lidocaine)
 </p>
 <p>
-`<strong>`{=html}Set up`</strong>`{=html}
+`<strong>Set up`</strong>
 </p>
 <p>
-`<img alt="" src="../media/image20.png" style="width:1.56319in;height:1.09306in"/>`{=html}Bed rotated 180 degrees.
+`<img alt="" src="../media/image20.png" style="width:1.56319in;height:1.09306in"/>Bed rotated 180 degrees.
 Leica microscope at head of bed, tower can be on the scrub side of
 microscope, NIM monitor and suction on the scrub side by the feet.
 </p>
@@ -537,7 +537,7 @@ implant site.
 Draw a lazy S incision 0.5cm behind the post-auricular crease.
 </p>
 <p>
-`<img alt="" src="../media/image21.png" style="width:1.94861in;height:1.71389in"/>`{=html}Place the NIM and curl the
+`<img alt="" src="../media/image21.png" style="width:1.94861in;height:1.71389in"/>Place the NIM and curl the
 leads before you stick the Tegaderm down. Test the monitor. Volume to
 max, voltage at 0.8.
 </p>
@@ -546,8 +546,8 @@ Put mastisol where the 1000 drapes will go and put the 1000 drapes
 down.
 </p>
 <p>
-`<strong>`{=html}Evaluate the TM with the microscope before you
-prep`</strong>`{=html}.
+`<strong>Evaluate the TM with the microscope before you
+prep`</strong>.
 </p>
 <p>
 Prep a wide area. Get the parts of the 1000 drapes that slip behind
@@ -557,7 +557,7 @@ posterior to anterior pulling the ear forward as you do. Redraw template
 markings again. Have scrub drape the microscope and the chairs.
 </p>
 <p>
-`<strong>`{=html}Procedure`</strong>`{=html}
+`<strong>Procedure`</strong>
 </p>
 <p>
 15 blade for incision, carry down to the temporalis fascia. Raise
@@ -569,7 +569,7 @@ placed) down to the bone. Raise the flap with a Lempert periosteal
 elevator to the spine of henle.
 </p>
 <p>
-`<img alt="" src="../media/image22.png" style="width:3.74306in;height:1.43333in"/>`{=html}Do a cortical mastoidectomy,
+`<img alt="" src="../media/image22.png" style="width:3.74306in;height:1.43333in"/>Do a cortical mastoidectomy,
 focus on the corner where the tegmen and EAC meet. Use a #6 until you
 hit Koerner septum, then switch to a #3 to expose the lateral
 semicircular canal, incus buttress and the fossa incudes. The incus
@@ -607,7 +607,7 @@ running 4-0 vicryl. Close deep layer with 4-0 vicyrl. Superficial with a
 fluffs. Then do a mastoid dressing (with 2 kerlexs)
 </p>
 <p>
-`<strong>`{=html}Post-op Instructions`</strong>`{=html}
+`<strong>Post-op Instructions`</strong>
 </p>
 <p>
 Mastoid/glasscock dressing for 24 hours. Then glasscock dressing at
@@ -652,9 +652,9 @@ Usually inject 1cc or 20 units/gland
 Dr Scott's OR Guide
 </h3>
 <p>
-For `<strong>`{=html}`<u>`{=html}Andrew Scott operative note`</u>`{=html}`</strong>`{=html} you need to
-focus on FINDINGS: `<strong>`{=html}+/- submucus cleft, Size of Tonsils, Size of
-Adenoids, Electrocautery Settings.`</strong>`{=html}
+For `<strong>`<u>Andrew Scott operative note`</u>`</strong> you need to
+focus on FINDINGS: `<strong>+/- submucus cleft, Size of Tonsils, Size of
+Adenoids, Electrocautery Settings.`</strong>
 </p>
 <p>
 []{#_Toc139824229 .anchor}Adenotonsillectomy
@@ -680,8 +680,8 @@ palate
 </li>
 <li>
 <p>
-Place soft suction catheter through nasal cavity; `<u>`{=html}place rolled
-gauze between soft suction catheter and clamp to secure in place`</u>`{=html}
+Place soft suction catheter through nasal cavity; `<u>place rolled
+gauze between soft suction catheter and clamp to secure in place`</u>
 (Vecchiotti does not use rolled gauze)
 </p>
 </li>
@@ -784,11 +784,11 @@ Tonsillectomy
 Patients
 </h4>
 <p>
-`<strong>`{=html}Orders`</strong>`{=html}: IVF, soft diet, pulse oximetry, cool
+`<strong>Orders`</strong>: IVF, soft diet, pulse oximetry, cool
 humidified air, ice pack to back of neck,
 </p>
 <p>
-`<strong>`{=html}Meds`</strong>`{=html}:
+`<strong>Meds`</strong>:
 </p>
 <p>
 Tylenol & ibuprofen liquid PO (should be standing orders, to be
@@ -802,7 +802,7 @@ patients \<6yo)
 Zofran IV, +/- Phenergine PR
 </p>
 <p>
-`<strong>`{=html}D/C Criteria`</strong>`{=html}: When you check soarian in the AM of
+`<strong>D/C Criteria`</strong>: When you check soarian in the AM of
 POD#1: make sure
 </p>
 <p>
@@ -819,16 +819,16 @@ Mandibular
 Distraction
 </h4>
 <p>
-POD#0-1: stay intubated. IV ancef or vanco. `<strong>`{=html}Trend cap
-gas`</strong>`{=html} (high risk of ↑↑PCO`<sub>`{=html}2`</sub>`{=html}) POD#2: clean pins w/ H2O2
+POD#0-1: stay intubated. IV ancef or vanco. `<strong>Trend cap
+gas`</strong> (high risk of ↑↑PCO`<sub>2`</sub>) POD#2: clean pins w/ H2O2
 and distraction begins.
 </p>
 <p>
-`<strong>`{=html}External devices:`</strong>`{=html} 1.5 turns (0.75mm) BID (
+`<strong>External devices:`</strong> 1.5 turns (0.75mm) BID (
 1.5mm/day)
 </p>
 <p>
-`<strong>`{=html}Internal devices:`</strong>`{=html} 1 turn (1mm) BID (2mm/day)
+`<strong>Internal devices:`</strong> 1 turn (1mm) BID (2mm/day)
 </p>
 <p>
 POD#5: wean sedation POD#6: extubate, dispo planning. Discharge on
@@ -845,9 +845,9 @@ POD#0-5: Make sure patient is on zosyn. Check for pressure necrosis
 (occiput, heels), and alar necrosis.
 </p>
 <p>
-`<strong>`{=html}Periextubation plan (POD#5):`</strong>`{=html} Decadron 0.25-0.5mg/kg
+`<strong>Periextubation plan (POD#5):`</strong> Decadron 0.25-0.5mg/kg
 to be given 13 hours prior to extubation q6hrs x3 so last dose is 1 hour
-prior to extubation. `<u>`{=html}Propofol "washout":`</u>`{=html} 8-10 hours prior to
+prior to extubation. `<u>Propofol "washout":`</u> 8-10 hours prior to
 planned extubation: start propofol 30mcg/kg/min (can titrate up to max
 100mcg/kg/min) then after 1 hour, can cut opioid and benzodiazepine
 infusions to 25-50% of previous level. continue precedex at same rate.
@@ -875,12 +875,12 @@ Glasscock x 24 hours then at night prn comfort
 <p>
 Ciprodex & Bactroban: Remove the cotton ball in ear, apply 3
 drops of ciprodex, then placed a new cotton ball coated in Bactroban
-back into the ear. Do this `<u>`{=html}three times a day`</u>`{=html}
+back into the ear. Do this `<u>three times a day`</u>
 </p>
 </li>
 <li>
 <p>
-`<u>`{=html}Sinus`</u>`{=html} precautions and `<u>`{=html}dry ear`</u>`{=html} precautions x 2
+`<u>Sinus`</u> precautions and `<u>dry ear`</u> precautions x 2
 weeks
 </p>
 </li>
@@ -900,7 +900,7 @@ Scott Cleft Lip
 & Cleft Palate
 </h4>
 <p>
-`<strong>`{=html}Medications`</strong>`{=html}:
+`<strong>Medications`</strong>:
 </p>
 <ul>
 <li>
@@ -931,7 +931,7 @@ LR @ mIVF rate
 <li>
 <p>
 Nasal saline spray: 4 drops to each nostril and to lip incisions
-q4 hours `<strong>`{=html}`<u>`{=html}\[cleft lip only\]`</u>`{=html}`</strong>`{=html} (this is super
+q4 hours `<strong>`<u>\[cleft lip only\]`</u>`</strong> (this is super
 important -- write an RN order to clean nose with q-tip if there is any
 crusting and do this on rounds in the AM)
 </p>
@@ -944,7 +944,7 @@ patients)
 </li>
 </ul>
 <p>
-`<strong>`{=html}Non-Medication Orders`</strong>`{=html}:
+`<strong>Non-Medication Orders`</strong>:
 </p>
 <ul>
 <li>
@@ -959,21 +959,21 @@ Activity ad lib
 </li>
 <li>
 <p>
-Regular Pedi Age-appropriate diet `<strong>`{=html}`<u>`{=html}\[cleft
-lip\]`</u>`{=html}`</strong>`{=html}
+Regular Pedi Age-appropriate diet `<strong>`<u>\[cleft
+lip\]`</u>`</strong>
 </p>
 </li>
 <li>
 <p>
-Soft/Pureed diet until follow up `<strong>`{=html}`<u>`{=html}\[cleft
-palate\]`</u>`{=html}`</strong>`{=html}
+Soft/Pureed diet until follow up `<strong>`<u>\[cleft
+palate\]`</u>`</strong>
 </p>
 </li>
 <li>
 <p>
 Welcome sleeves at all times (except under direct supervision) x2
-weeks (`<em>`{=html}sign the restraint order form in PACU otherwise you WILL get
-a page at night)`</em>`{=html}
+weeks (`<em>sign the restraint order form in PACU otherwise you WILL get
+a page at night)`</em>
 </p>
 </li>
 <li>
@@ -1020,12 +1020,12 @@ No ointment of any kind to incisions
 </li>
 <li>
 <p>
-`<u>`{=html}Follow up is 3 weeks`</u>`{=html}
+`<u>Follow up is 3 weeks`</u>
 </p>
 </li>
 </ul>
 <p>
-`<a href="../index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="../index.html">Back to homepage`</a>
 </p>
 </li>
 </ul>

--- a/perioperative-aspirin-anticoagulation-guide.md
+++ b/perioperative-aspirin-anticoagulation-guide.md
@@ -6,7 +6,7 @@ title: PERIOPERATIVE ASPIRIN/ANTICOAGULATION GUIDE
 ANTI PLATELET
 </h2>
 <p>
-`<strong>`{=html}Patients with stents:`</strong>`{=html} ASA + P2Y12 (dual) therapy
+`<strong>Patients with stents:`</strong> ASA + P2Y12 (dual) therapy
 </p>
 <ul>
 <li>
@@ -79,14 +79,14 @@ Patients with chronically high risk, use a bridging agent
 </li>
 </ul>
 <p>
-`<strong>`{=html}Wafarin`</strong>`{=html} -- stop 5 days before surgery. Vit K if INR
+`<strong>Wafarin`</strong> -- stop 5 days before surgery. Vit K if INR
 \>1.5 \[can normally restart 12-24hr postop. Wont be therapeutic for
 3days\]. Bridge if recent stroke, heart valve, afib w/ 5-6 CHAD2 with
 therapeudic LWMH (1mg/kg BID) 3 days preop (2days after stopping
 warfarin)
 </p>
 <p>
-`<strong>`{=html}DTIs`</strong>`{=html}: Dabigatran (Pradaxa), Rivaroxaban
+`<strong>DTIs`</strong>: Dabigatran (Pradaxa), Rivaroxaban
 (Xarelto)/Apixaban (Eliquis) --- stop 2-3days before surgery (2 days if
 low risk, 3 days if high risk, 4days if patient has renal failure). No
 bridging needs. Restart POD1-2 for low bleeding risk procedures and
@@ -95,7 +95,7 @@ for 1-2 days). Peak effect only takes 2-3hrs. Can check aPTT \[for
 pradaxa\] or Factor Xa \[for xarleto\] to assess if pradaxa is cleared
 </p>
 <p>
-`<strong>`{=html}When to bridge (typically warfarin patients).`</strong>`{=html}
+`<strong>When to bridge (typically warfarin patients).`</strong>
 </p>
 <ul>
 <li>
@@ -109,7 +109,7 @@ Afib only w/ CHADS2 score 5-6 \[important, BRIDGE trial\]. Bridge pre&post op un
 </li>
 </ul>
 <p>
-`<strong>`{=html}How to bridge`</strong>`{=html}
+`<strong>How to bridge`</strong>
 </p>
 <p>
 Choice of therapeutic LWMH \[1mg/kg BID\] or intermediate dose (40mg BID) unless in renal failure then use UFH
@@ -183,14 +183,14 @@ be fatal).
 </ul>
 <blockquote>
 <p>
-`<strong>`{=html}Voiding`</strong>`{=html} -- if patient hasn't voided 6 hours after
+`<strong>Voiding`</strong> -- if patient hasn't voided 6 hours after
 procedure, get bladder scan. If \>400cc, straight cath, if \<400cc,
 repeat scan q2hours until either \>400cc or spontaneously voiding. If
-patient still retaining 6 hours after 1`<sup>`{=html}st`</sup>`{=html} straight cath,
+patient still retaining 6 hours after 1`<sup>st`</sup> straight cath,
 place foley and start Flomax
 </p>
 <p>
-`<strong>`{=html}Nutrition`</strong>`{=html}`<br/>`{=html}
+`<strong>Nutrition`</strong>`<br/>
 If you can't get nutrition here is an easy starting TF regiment:
 </p>
 <p>
@@ -221,7 +221,7 @@ For free water flushes: 7mL/kg/day split up either BID, TID, QID
 Electrolytes
 </h4>
 <p>
-`<strong>`{=html}Hypokalemia`</strong>`{=html} (Keep level \>2 for trauma/arrhythmia
+`<strong>Hypokalemia`</strong> (Keep level \>2 for trauma/arrhythmia
 patients)
 </p>
 <ul>
@@ -239,12 +239,12 @@ hypomagnesemia simultaneously.
 </li>
 </ul>
 <p>
-`<strong>`{=html}Hyperkalemia`</strong>`{=html}
+`<strong>Hyperkalemia`</strong>
 </p>
 <ul>
 <li>
 <p>
-`<u>`{=html}Between 5-6`</u>`{=html}:
+`<u>Between 5-6`</u>:
 </p>
 <ol type="1">
 <li>
@@ -269,7 +269,7 @@ diuretics.
 </li>
 <li>
 <p>
-`<u>`{=html}\>6 or symptomatic`</u>`{=html}:
+`<u>\>6 or symptomatic`</u>:
 </p>
 <ul>
 <li>
@@ -322,7 +322,7 @@ Optional: Furosemide 10-40mg IV / double their daily dose (onset
 </li>
 </ul>
 <p>
-`<strong>`{=html}Hypocalcemia`</strong>`{=html}
+`<strong>Hypocalcemia`</strong>
 </p>
 <p>
 
@@ -332,19 +332,19 @@ Optional: Furosemide 10-40mg IV / double their daily dose (onset
     <ul>
     <li>
     <p>
-    Very low (Ca`<sup>`{=html}2+`</sup>`{=html} \<7.5mg/dL or iCa`<sup>`{=html}2+`</sup>`{=html}
+    Very low (Ca`<sup>2+`</sup> \<7.5mg/dL or iCa`<sup>2+`</sup>
     \<3mg/dL)
     </p>
     <ul>
     <li>
     <p>
-    give IV dose (also start PO), repeat iCa`<sup>`{=html}2+`</sup>`{=html} &
-    Mg`<sup>`{=html}2+`</sup>`{=html} in 4-6 hours until normal.
+    give IV dose (also start PO), repeat iCa`<sup>2+`</sup> &
+    Mg`<sup>2+`</sup> in 4-6 hours until normal.
     </p>
     </li>
     <li>
     <p>
-    Low (Ca`<sup>`{=html}2+`</sup>`{=html} 7.5-8.5 or iCa`<sup>`{=html}2+`</sup>`{=html} 3.0-4.2)
+    Low (Ca`<sup>2+`</sup> 7.5-8.5 or iCa`<sup>2+`</sup> 3.0-4.2)
     </p>
     <ul>
     <li>
@@ -361,31 +361,31 @@ Optional: Furosemide 10-40mg IV / double their daily dose (onset
     </ul>
 
 <p>
-`<em>`{=html}`<strong>`{=html}IV Calcium`</strong>`{=html}`</em>`{=html}: Calcium gluconate 1-2g (2g more
+`<em>`<strong>IV Calcium`</strong>`</em>: Calcium gluconate 1-2g (2g more
 commonly given)
 </p>
 <p>
-`<em>`{=html}`<strong>`{=html}PO Calcium`</strong>`{=html}`</em>`{=html}: typically 1.5-2g of elemental
+`<em>`<strong>PO Calcium`</strong>`</em>: typically 1.5-2g of elemental
 calcium (either as calcium carbonate or calcium citrate typically
 divided into TID dosing). Increase total daily dose by 1-2g of elemental
 calcium until calcium normalizes. 500mg PO x appropriate doses
 </p>
 <p>
-In `<u>`{=html}children`</u>`{=html} it is 25 to 50 mg/kg
+In `<u>children`</u> it is 25 to 50 mg/kg
 </p>
 <p>
 Forms: Calcium carbonate: best when patient taking PO. Calcium
 citrate: best when patients are NPO
 </p>
 <p>
-`<em>`{=html}`<strong>`{=html}Vitamin D (Calcitriol)`</strong>`{=html}`</em>`{=html}: Start at
+`<em>`<strong>Vitamin D (Calcitriol)`</strong>`</em>: Start at
 0.25-0.5mcg qdaily. Can increase to 0.5-2mcg daily.
 </p>
 <p>
 Children \<1yo: 0.04-0.08 mcg/kg daily. \>1yo 0.25mcg daily
 </p>
 <p>
-`<strong>`{=html}Hypercalcemia`</strong>`{=html}
+`<strong>Hypercalcemia`</strong>
 </p>
 <p>
 
@@ -402,7 +402,7 @@ Children \<1yo: 0.04-0.08 mcg/kg daily. \>1yo 0.25mcg daily
         3.  Hold thiazide diuretics
             </p>
             <p>
-            `<strong>`{=html}Hypomagnesemia`</strong>`{=html} (Keep level \>2 for
+            `<strong>Hypomagnesemia`</strong> (Keep level \>2 for
             trauma/arrhythmia patients)
             </p>
             <p>
@@ -415,7 +415,7 @@ Children \<1yo: 0.04-0.08 mcg/kg daily. \>1yo 0.25mcg daily
                     daily
                     </p>
                     <p>
-                    `<strong>`{=html}Hypermagnesemia`</strong>`{=html}
+                    `<strong>Hypermagnesemia`</strong>
                     </p>
                     <p>
 
@@ -426,7 +426,7 @@ Children \<1yo: 0.04-0.08 mcg/kg daily. \>1yo 0.25mcg daily
                         3.  Calcium gluconate 2g IV (stabilizes cardiac membrane)
                             </p>
                             <p>
-                            `<strong>`{=html}Hypophosphatemia`</strong>`{=html} (not usually treated in
+                            `<strong>Hypophosphatemia`</strong> (not usually treated in
                             non-transplant, non-NPO floor patients)
                             </p>
                             <p>
@@ -453,7 +453,7 @@ Children \<1yo: 0.04-0.08 mcg/kg daily. \>1yo 0.25mcg daily
                                     etc)
                                     </p>
                                     <p>
-                                    `<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+                                    `<a href="index.html">Back to homepage`</a>
                                     </p>
                                     </li>
                                     </ul>

--- a/radiology-levels-of-the-neck.md
+++ b/radiology-levels-of-the-neck.md
@@ -17,8 +17,8 @@ The central compartment around the larynx and trachea is level VI.
 </li>
 </ul>
 <p>
-Example cross-sectional images can be viewed at `<a href="http://headneckbrainspine.com" target="_blank" rel="noopener">`{=html}headneckbrainspine.com`</a>`{=html}.
+Example cross-sectional images can be viewed at `<a href="http://headneckbrainspine.com" target="_blank" rel="noopener">headneckbrainspine.com`</a>.
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/review-of-systems.md
+++ b/review-of-systems.md
@@ -114,5 +114,5 @@ Episodes of respiratory distress or poor weight gain
 </li>
 </ul>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/rhinology.md
+++ b/rhinology.md
@@ -48,7 +48,7 @@ Nasal steroids (Flonase/Nasacort/Nasonex/Rhinocort)
 </li>
 <li>
 <p>
-Can give oral 2`<sup>`{=html}nd`</sup>`{=html} gen antihistamines if sneezing,
+Can give oral 2`<sup>nd`</sup> gen antihistamines if sneezing,
 itching
 </p>
 </li>
@@ -97,7 +97,7 @@ animals more frequently (not great evidence)
 </li>
 <li>
 <p>
-`<strong>`{=html}Inferior turbinate reduction:`</strong>`{=html} can be offered if
+`<strong>Inferior turbinate reduction:`</strong> can be offered if
 allergic rhinitis \_ nasal obstruction+ enlarged inferior turbinates +
 failed medical management. Dr. Rebeiz likes to offer one side at a time
 to see if patients get a response before he does the other
@@ -148,7 +148,7 @@ Probably safer and more effective
 </li>
 <li>
 <p>
-1`<sup>`{=html}st`</sup>`{=html} dose in office. After that, administered at
+1`<sup>st`</sup> dose in office. After that, administered at
 home
 </p>
 </li>
@@ -164,16 +164,16 @@ More likely to cause GI upset
 </ol>
 <blockquote>
 <p>
-`<strong>`{=html}Allergy testing`</strong>`{=html}:
+`<strong>Allergy testing`</strong>:
 </p>
 </blockquote>
 <ol type="I">
 <li>
 <p>
-`<u>`{=html}Skin testing`</u>`{=html}: contraindicated in eczema, uncontrolled
+`<u>Skin testing`</u>: contraindicated in eczema, uncontrolled
 asthma, cardiovascular disease or on beta-blockers (Can do blood tests
-on these patients instead). `<strong>`{=html}Patients should stop antihistamines
-48-72hrs prior`</strong>`{=html}
+on these patients instead). `<strong>Patients should stop antihistamines
+48-72hrs prior`</strong>
 </p>
 </li>
 <li>
@@ -189,28 +189,28 @@ enlarges (use 1ml of previous strength + 4ml of dilute)
 <h4 class="unnumbered" id="allergens-will-associated-oral-allergy-triggers">
 `<img
 src="media/image23.png"
-style="width:1.74097in;height:2.26458in" />`{=html}Allergens (will associated
+style="width:1.74097in;height:2.26458in" />Allergens (will associated
 oral allergy triggers)
 </h4>
 <p>
-`<strong>`{=html}Spring`</strong>`{=html} --- trees (birch) → Apples, Peaches, Carrots,
+`<strong>Spring`</strong> --- trees (birch) → Apples, Peaches, Carrots,
 Peanuts
 </p>
 <p>
-`<strong>`{=html}Summer`</strong>`{=html} --- grass → dates, orange, tomato,
+`<strong>Summer`</strong> --- grass → dates, orange, tomato,
 watermelon
 </p>
 <p>
-`<strong>`{=html}Summer/Fall`</strong>`{=html} --- Mugwort → celery, carrots
+`<strong>Summer/Fall`</strong> --- Mugwort → celery, carrots
 </p>
 <p>
-`<strong>`{=html}Fall`</strong>`{=html} --- Ragweed → bananas, melon
+`<strong>Fall`</strong> --- Ragweed → bananas, melon
 </p>
 <p>
-`<strong>`{=html}Nighttime`</strong>`{=html} --- dust mites
+`<strong>Nighttime`</strong> --- dust mites
 </p>
 <p>
-`<strong>`{=html}Cross-reactive oral allergens`</strong>`{=html}:
+`<strong>Cross-reactive oral allergens`</strong>:
 </p>
 <p>
 Peach → 55% of apple, plum, pear
@@ -235,66 +235,66 @@ Other causes of
 Rhinitis
 </h3>
 <p>
-`<strong>`{=html}Acid reflux`</strong>`{=html}. MCC of rhinitis. Especially at
+`<strong>Acid reflux`</strong>. MCC of rhinitis. Especially at
 night.
 </p>
 <p>
-`<strong>`{=html}Rhinoscleroma:`</strong>`{=html} nasal deformity 2/2 klebsiella
+`<strong>Rhinoscleroma:`</strong> nasal deformity 2/2 klebsiella
 </p>
 <p>
-`<strong>`{=html}Rhinosporidososis`</strong>`{=html}: strawberry friable nasal mass 2/2
+`<strong>Rhinosporidososis`</strong>: strawberry friable nasal mass 2/2
 rhinosporidium seebri
 </p>
 <p>
-`<strong>`{=html}Nonallergic rhinitis w/ eosinophilia Syndrome
-(NARES):`</strong>`{=html} associated w/ aspirin allergies.
+`<strong>Nonallergic rhinitis w/ eosinophilia Syndrome
+(NARES):`</strong> associated w/ aspirin allergies.
 </p>
 <p>
-`<strong>`{=html}Rhinitis of pregnancy`</strong>`{=html}: avoid afrin. Consider
+`<strong>Rhinitis of pregnancy`</strong>: avoid afrin. Consider
 turbinate reduction
 </p>
 <p>
-`<strong>`{=html}Atrophic Rhinitis`</strong>`{=html}: Includes empty nose syndrome.
+`<strong>Atrophic Rhinitis`</strong>: Includes empty nose syndrome.
 </p>
 <p>
-`<strong>`{=html}Rhinitis Medicamentosa`</strong>`{=html}: due to overuse of afrin
+`<strong>Rhinitis Medicamentosa`</strong>: due to overuse of afrin
 </p>
 <p>
-`<strong>`{=html}Vasomotor Rhinitis`</strong>`{=html}: diagnosis of exclusion.
+`<strong>Vasomotor Rhinitis`</strong>: diagnosis of exclusion.
 </p>
 <h3 class="unnumbered" id="sinusitis-clinical-practice-guideline-italicized-not-part-of-guidelines">
 Sinusitis
--- Clinical Practice Guideline (`<em>`{=html}Italicized`</em>`{=html} = not part of
+-- Clinical Practice Guideline (`<em>Italicized`</em> = not part of
 guidelines)
 </h3>
 <p>
-`<strong>`{=html}ARS`</strong>`{=html}: purulent nasal `<strong>`{=html}drainage`</strong>`{=html}
-accompanied by nasal `<strong>`{=html}obstruction`</strong>`{=html}, facial
-`<strong>`{=html}pain`</strong>`{=html}-pressure fullness,
+`<strong>ARS`</strong>: purulent nasal `<strong>drainage`</strong>
+accompanied by nasal `<strong>obstruction`</strong>, facial
+`<strong>pain`</strong>-pressure fullness,
 </p>
 <p>
-or both. `<strong>`{=html}Suspect Acute Bacterial Rhinosinusitis (ABRS) if
-symptoms \>10days or get better then worse.`</strong>`{=html} If you see
+or both. `<strong>Suspect Acute Bacterial Rhinosinusitis (ABRS) if
+symptoms \>10days or get better then worse.`</strong> If you see
 patients w/ symptoms \<10days, this is likely viral: give Flonase,
 nasal saline, Tylenol/ibuprofen.
 </p>
 <p>
-`<strong>`{=html}ABRS:`</strong>`{=html} amox or augmentin x5-10days (doxycycline or
+`<strong>ABRS:`</strong> amox or augmentin x5-10days (doxycycline or
 levoquin or moxifloxacin for PCN allergic patients). Can do watchful
 waiting for 7 days in reliable patients. If no improvement after 7 days:
 give antibiotics (if watchful waiting) or change antibiotics (if patient
 given amox/augmentin, do doxycycline, Levaquin, or combo clindamycin +
-3`<sup>`{=html}rd`</sup>`{=html} gen cephalosporin)
+3`<sup>rd`</sup> gen cephalosporin)
 </p>
 <p>
-`<em>`{=html}`<u>`{=html}Frontal sinusitis`</u>`{=html}: treat more aggressively`</em>`{=html}
+`<em>`<u>Frontal sinusitis`</u>: treat more aggressively`</em>
 </p>
 <p>
-`<strong>`{=html}Recurrent ABRS`</strong>`{=html}: 4+ episodes a year with periods
+`<strong>Recurrent ABRS`</strong>: 4+ episodes a year with periods
 where symptoms are gone/
 </p>
 <p>
-`<strong>`{=html}Chronic Rhinosinusitis`</strong>`{=html}: \>12 weeks of symptoms.
+`<strong>Chronic Rhinosinusitis`</strong>: \>12 weeks of symptoms.
 Confirm diagnosis with clinical exam (anterior rhinoscopy, nasal
 endoscopy) or CT sinus. Patients should be evaluated for asthma, cystic
 fibrosis, immunocompromised state, and ciliary dyskinesia +/- allergy
@@ -306,9 +306,9 @@ budesonide rinses maybe useful for CRS w/ polyps but not officially
 recommended. Don't give antifungals.
 </p>
 <p>
-`<em>`{=html}If no response to Flonase, can give course of oral steroids (2-4
+`<em>If no response to Flonase, can give course of oral steroids (2-4
 week) + antibiotics (macrolides especially -- for 3-6 weeks) at same time
-(especially for CRSw/ polyps)`</em>`{=html}
+(especially for CRSw/ polyps)`</em>
 </p>
 <h4 class="unnumbered" id="allergic-fungal-rhinosinusitis">
 Allergic
@@ -350,8 +350,8 @@ Positive fungal stain of sinus content
 <li>
 <p>
 `<img src="media/image24.jpeg"
-style="width:1.73542in;height:1.98611in" />`{=html}`<strong>`{=html}Mycetoma (Fungal
-Ball)`</strong>`{=html}: typically aspergillus (Y-shaped 45 degree septated
+style="width:1.73542in;height:1.98611in" />`<strong>Mycetoma (Fungal
+Ball)`</strong>: typically aspergillus (Y-shaped 45 degree septated
 hyphae) in one sinus treated with surgery
 </p>
 </li>
@@ -396,20 +396,20 @@ recalcitrant form of disease)
 </p>
 <p>
 R/O: encephalocele, inverted papilloma, glioma, antrochoanal polyp
-(retention cyst of max sinus that protrudes through antrum). `<strong>`{=html}Get
-CT scan, allergy test`</strong>`{=html}
+(retention cyst of max sinus that protrudes through antrum). `<strong>Get
+CT scan, allergy test`</strong>
 </p>
 <p>
 Surgical Tx: Do FESS -- polypectomy, sphenoidethmoidectomy, max
 antrostomy. Send specimen to r/o inverted papilloma
 </p>
 <p>
-Medical Tx : aggressive allergy mgmt`<strong>`{=html}, flonase`</strong>`{=html} +/-
+Medical Tx : aggressive allergy mgmt`<strong>, flonase`</strong> +/-
 rhinocort aqua (Budesonide) or Azelastine HCl 137mcg/spray (H1 blocker)
 \[2 sprays BID\], avoid ASA
 </p>
 <p>
-`<em>`{=html}Severe disease`</em>`{=html}: consider low-dose steroids, budesonide
+`<em>Severe disease`</em>: consider low-dose steroids, budesonide
 rinses, corticosteroid eluding stents (propel)
 </p>
 <h3 class="unnumbered" id="inverted-papilloma">
@@ -480,7 +480,7 @@ cavity → Lethal Midline Granuloma
 Epistaxis
 </h3>
 <p>
-`<strong>`{=html}Anatomy`</strong>`{=html}
+`<strong>Anatomy`</strong>
 </p>
 <ol type="I">
 <li>
@@ -503,9 +503,9 @@ Hereditary Hemorrhagic
 Telangiectasia
 </h4>
 <p>
-Autosomal dominant. Tx: NdYAG laser. `<strong>`{=html}Saunder's
-dermoplasty`</strong>`{=html}: removal telangiectic mucosa and replaced with STSG
-`<strong>`{=html}Young's procedure`</strong>`{=html}: close nasal cavity. For acute bleeds
+Autosomal dominant. Tx: NdYAG laser. `<strong>Saunder's
+dermoplasty`</strong>: removal telangiectic mucosa and replaced with STSG
+`<strong>Young's procedure`</strong>: close nasal cavity. For acute bleeds
 in the ED: surgiflo works well.
 </p>
 <h3 class="unnumbered" id="adult-obstructive-sleep-apnea">
@@ -513,15 +513,15 @@ Adult
 Obstructive Sleep Apnea
 </h3>
 <p>
-`<em>`{=html}See Dr. Wein's Head & Neck clinic section for Inspire
-patients`</em>`{=html}
+`<em>See Dr. Wein's Head & Neck clinic section for Inspire
+patients`</em>
 </p>
 <p>
-`<strong>`{=html}Apnea`</strong>`{=html} = cessation of nasal air pressure \[defined as
+`<strong>Apnea`</strong> = cessation of nasal air pressure \[defined as
 90% of baseline\] (for \>10secs)
 </p>
 <p>
-`<strong>`{=html}Hypopnea`</strong>`{=html}:
+`<strong>Hypopnea`</strong>:
 </p>
 <ul>
 <li>
@@ -533,23 +533,23 @@ desat (for \>10 secs)
 <li>
 <p>
 30+3/arousal criteria: drop in 30% of baseline + 3% O2 desat
-`<strong>`{=html}or`</strong>`{=html} an arousal (\>10secs)
+`<strong>or`</strong> an arousal (\>10secs)
 </p>
 </li>
 </ul>
 <p>
-`<strong>`{=html}AHI`</strong>`{=html}: Apnea+hypopnea per hour. AHI \> 5 = OSA.
+`<strong>AHI`</strong>: Apnea+hypopnea per hour. AHI \> 5 = OSA.
 \>15 = moderate. \>30 = severe
 </p>
 <p>
-`<strong>`{=html}RERA`</strong>`{=html}: Arousal preceded by inc. respiratory effort
+`<strong>RERA`</strong>: Arousal preceded by inc. respiratory effort
 (for \>10sec)
 </p>
 <p>
-`<strong>`{=html}RDI`</strong>`{=html}: Apnea+hypopnea+RERA/hour
+`<strong>RDI`</strong>: Apnea+hypopnea+RERA/hour
 </p>
 <p>
-`<strong>`{=html}Central Apnea:`</strong>`{=html} cessation of respiratory effort
+`<strong>Central Apnea:`</strong> cessation of respiratory effort
 during apnea. \>5 central apneas/hour = primary central sleep
 apnea.
 </p>
@@ -576,9 +576,9 @@ Nasopharynx: Adenoids?
 </li>
 <li>
 <p>
-Velopharynx: do `<strong>`{=html}mullers maneuver`</strong>`{=html}: attempt to
-breathing in with mouth/nose closed. `<strong>`{=html}If \>50%
-collapse`</strong>`{=html}→ retropalatal/retrolingual collapse
+Velopharynx: do `<strong>mullers maneuver`</strong>: attempt to
+breathing in with mouth/nose closed. `<strong>If \>50%
+collapse`</strong>→ retropalatal/retrolingual collapse
 (velopharynx)
 </p>
 </li>
@@ -609,7 +609,7 @@ Diverticulum
 Presents w/ dysphagia and regurgitation of indigested food
 </p>
 <p>
-`<strong>`{=html}Pulsion`</strong>`{=html} diverticulum at Killians Triangle (between
+`<strong>Pulsion`</strong> diverticulum at Killians Triangle (between
 cricopharyngeus and inferior constrictor). Occurs on left side 90% of
 time
 </p>
@@ -622,7 +622,7 @@ Ask: about exposure to heavy metals and job (woodworkers inc. rate of
 SCCA (if soft wood work) and Adenocarcinoma (if hard wood))
 </p>
 <p>
-`<strong>`{=html}Types`</strong>`{=html}:
+`<strong>Types`</strong>:
 </p>
 <p>
 SCCA, Adenocarcinoma (in wood/leather workers), Adenoid Cystic (slow
@@ -637,20 +637,20 @@ Otolaryngologic
 Manifestations of Autoimmune Diseases
 </h3>
 <p>
-`<strong>`{=html}W.A.S.: Autoimmune`</strong>`{=html} laryngeal manifestations →
+`<strong>W.A.S.: Autoimmune`</strong> laryngeal manifestations →
 Wegener's=supraglottic. Amyloid = Glottic. Sarcoidosis= Subglottic
 </p>
 <p>
-`<strong>`{=html}Wegener's (Granulomatosis with Polyangiitis GPA):`</strong>`{=html} MC
+`<strong>Wegener's (Granulomatosis with Polyangiitis GPA):`</strong> MC
 H&N symptom recurrent sinusitis. Also associated w/ septal
 perforation, chronic otitis, subglottic stenosis. Order c-ANCA
 </p>
 <p>
-`<strong>`{=html}Amyloidosis`</strong>`{=html}: causes macroglossia, deposits on TVF.
+`<strong>Amyloidosis`</strong>: causes macroglossia, deposits on TVF.
 Requires biopsy for diagnosis
 </p>
 <p>
-`<strong>`{=html}Sarcoidosis`</strong>`{=html}: can cause `<u>`{=html}supraglottic`</u>`{=html} mass
+`<strong>Sarcoidosis`</strong>: can cause `<u>supraglottic`</u> mass
 (epiglottis) w/ TVF immobility. Also risk of FN palsy (w/ uveitis and
 parotitis = Heerfordt's disease) Order ACE levels
 </p>
@@ -671,13 +671,13 @@ Look at coronal & axial
 <li>
 <p>
 Identify uncinate process and its relation to medial orbital
-wall`<strong>`{=html}. Check that it is not lateralized as a lateralized uncinate
-= easy orbital entry`</strong>`{=html}
+wall`<strong>. Check that it is not lateralized as a lateralized uncinate
+= easy orbital entry`</strong>
 </p>
 </li>
 <li>
 <p>
-Look for `<strong>`{=html}Haller cells`</strong>`{=html} (infraorbital cells) as
+Look for `<strong>Haller cells`</strong> (infraorbital cells) as
 thse crowd middle meatus and can be hard to reach
 </p>
 </li>
@@ -690,12 +690,12 @@ present, may need angled instruments)
 </ul>
 <p>
 `<img src="media/image25.png"
-style="width:3.85in;height:1.62778in" />`{=html}
+style="width:3.85in;height:1.62778in" />
 </p>
 <p>
 Figure 8: (Left) Haller cell (Right) Lateralized uncinate process.
-Palmer and Chiu, `<em>`{=html}Atlas of Endoscopic Sinus and Skull Base
-Surgery`</em>`{=html}.
+Palmer and Chiu, `<em>Atlas of Endoscopic Sinus and Skull Base
+Surgery`</em>.
 </p>
 <h4 class="unnumbered" id="ethmoidectomysphenoidectomy-figure-8">
 Ethmoidectomy/Sphenoidectomy
@@ -704,7 +704,7 @@ Ethmoidectomy/Sphenoidectomy
 <ul>
 <li>
 <p>
-Sagittal Look at `<strong>`{=html}slope of skull base`</strong>`{=html} the more it
+Sagittal Look at `<strong>slope of skull base`</strong> the more it
 slopes, the lower your entry through the basal lamella should be (image
 1 below)
 </p>
@@ -712,8 +712,8 @@ slopes, the lower your entry through the basal lamella should be (image
 <li>
 <p>
 The height of the skull base doesn't matter as much as the
-difference between the height of the `<strong>`{=html}roof of maxillary to height
-of skull base`</strong>`{=html} matters. Maxillary sinus roof is ur landmark, if
+difference between the height of the `<strong>roof of maxillary to height
+of skull base`</strong> matters. Maxillary sinus roof is ur landmark, if
 the maxillary sinus roof is high, and skull base is low, u may enter
 basal lamella too high (image 2)
 </p>
@@ -727,7 +727,7 @@ cribriform plate. Type I: 1-3mm; Type 2: 3-7mm; Type 3 (most dangerous)
 </li>
 <li>
 <p>
-Identify `<strong>`{=html}onodi cells`</strong>`{=html} (check coronals) - this is
+Identify `<strong>onodi cells`</strong> (check coronals) - this is
 a posterior ethmoid cell superior or lateral to sphenoid. Important
 because the sphenoid isn't posterior to it but the optic nerve/apex is!
 (Image
@@ -739,7 +739,7 @@ because the sphenoid isn't posterior to it but the optic nerve/apex is!
 </li>
 <li>
 <p>
-Check i`<strong>`{=html}ntrasinus septum of sphenoid`</strong>`{=html} (check
+Check i`<strong>ntrasinus septum of sphenoid`</strong> (check
 axials) to make sure its doesn't lead to carotid (Image 4)
 </p>
 </li>
@@ -750,8 +750,8 @@ Frontal Sinusotomy
 <ul>
 <li>
 <p>
-Check sagittal. Determine `<strong>`{=html}anterior-posterior dimension of
-frontal recess`</strong>`{=html}. If small, stripping the mucosa in the recess =
+Check sagittal. Determine `<strong>anterior-posterior dimension of
+frontal recess`</strong>. If small, stripping the mucosa in the recess =
 high likelihood of restenosis
 </p>
 </li>
@@ -777,7 +777,7 @@ Around frontal recess
 <ol type="1">
 <li>
 <p>
-`<strong>`{=html}Agger nasi`</strong>`{=html}
+`<strong>Agger nasi`</strong>
 </p>
 </li>
 <li>
@@ -808,7 +808,7 @@ Type 4 within frontal sinus
 </ul>
 <p>
 `<img src="media/image26.png"
-style="width:3.85in;height:2.80417in" />`{=html}
+style="width:3.85in;height:2.80417in" />
 </p>
 <p>
 Figure 9: Palmer and Chiu, Atlas of Endoscopic Sinus and Skull Base
@@ -861,7 +861,7 @@ SURGERY:
 <li>
 <p>
 `<img src="media/image27.png"
-style="width:1.65625in;height:1.48542in" />`{=html}`<strong>`{=html}Inject`</strong>`{=html} 1%
+style="width:1.65625in;height:1.48542in" />`<strong>Inject`</strong> 1%
 lido + epi : root of middle turb and lateral nasal wall. Inject with
 patties in place in middle meatus
 </p>
@@ -874,48 +874,48 @@ turb.
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Turbinoplasty`</u>`{=html}`</strong>`{=html} with up biting tru-cut
+`<strong>`<u>Turbinoplasty`</u>`</strong> with up biting tru-cut
 along inferomedial, inferior, inferolateral surface of middle turb and
 hold medially for 30 secs
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Uncinectomy`</u>`{=html}`</strong>`{=html}: Use `<strong>`{=html}ostium
-seeker`</strong>`{=html} to probe max ostium. With `<strong>`{=html}cottle`</strong>`{=html},
+`<strong>`<u>Uncinectomy`</u>`</strong>: Use `<strong>ostium
+seeker`</strong> to probe max ostium. With `<strong>cottle`</strong>,
 perform uncinectomy, then remove inferior portion with a small
-`<strong>`{=html}backbiter`</strong>`{=html}. Use `<strong>`{=html}ostium seeker`</strong>`{=html} to pull
-the superior uncinate and remove with a `<strong>`{=html}upbiting
-tru-bite`</strong>`{=html}. Used `<strong>`{=html}curved navigation suction`</strong>`{=html} to
+`<strong>backbiter`</strong>. Use `<strong>ostium seeker`</strong> to pull
+the superior uncinate and remove with a `<strong>upbiting
+tru-bite`</strong>. Used `<strong>curved navigation suction`</strong> to
 confirm you've opened it up.
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Widen maxillary antrostomy`</u>`{=html}`</strong>`{=html} by excising
+`<strong>`<u>Widen maxillary antrostomy`</u>`</strong> by excising
 the posterior fontanelle posterior to the maxillary os with a
-`<strong>`{=html}straight tru-bite`</strong>`{=html}
+`<strong>straight tru-bite`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Anterior ethmoidectomy`</u>`{=html}`</strong>`{=html} enter ethmoid
-bullae with suction, remove pieces with `<strong>`{=html}blakesley
-forcep`</strong>`{=html}
+`<strong>`<u>Anterior ethmoidectomy`</u>`</strong> enter ethmoid
+bullae with suction, remove pieces with `<strong>blakesley
+forcep`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Posterior ethmoidectomy`</u>`{=html}`</strong>`{=html}: identify basal
+`<strong>`<u>Posterior ethmoidectomy`</u>`</strong>: identify basal
 lamella (horizontal/vertical portion). Enter basal lamella with a
-`<strong>`{=html}j curette`</strong>`{=html} on inferior/medial aspect below level of the
+`<strong>j curette`</strong> on inferior/medial aspect below level of the
 roof of the maxillary sinus
 </p>
 </li>
 </ul>
 <p>
 `<img src="media/image28.png"
-style="width:2.96494in;height:3.04348in" />`{=html}
+style="width:2.96494in;height:3.04348in" />
 </p>
 <p>
 Figure 10: Palmer and Chiu, Atlas of Endoscopic Sinus and Skull Base
@@ -924,29 +924,29 @@ Surgery.
 <ul>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Sphenoidotomy`</u>`{=html}`</strong>`{=html}: anterior face of sphenoid
+`<strong>`<u>Sphenoidotomy`</u>`</strong>: anterior face of sphenoid
 = 7cm from nasal sill. Find it medial to superior turbinate or the
 bolger's box method (the box is superior turbinate \[medial\], lamina
 papyracea \[laterally\], skull base, basal lamella: locate it
 inferior/medially). Use a straight tru-bite to transect lower 1/3 of
 superior turbinate to better visualize sphenoid os, then use j curette
-to enlarge os `<strong>`{=html}laterally`</strong>`{=html}
+to enlarge os `<strong>laterally`</strong>
 </p>
 </li>
 <li>
 <p>
-Come back along skull base using `<strong>`{=html}J
-curette`</strong>`{=html}
+Come back along skull base using `<strong>J
+curette`</strong>
 </p>
 </li>
 <li>
 <p>
-`<strong>`{=html}`<u>`{=html}Frontal sinusotomy`</u>`{=html}:`</strong>`{=html} Enter frontal sinus
-with `<strong>`{=html}ostium seeker`</strong>`{=html} then curved suction. Take down the
+`<strong>`<u>Frontal sinusotomy`</u>:`</strong> Enter frontal sinus
+with `<strong>ostium seeker`</strong> then curved suction. Take down the
 superior part of the uncinate if that hasn't already been done. If there
-is an agger nasi cell, get a `<strong>`{=html}45 or 70 degree scope`</strong>`{=html} and
-take down `<u>`{=html}inferior`</u>`{=html} part of agger nasi. `<u>`{=html}Do not strip
-mucosa`</u>`{=html}. A lot of people just do balloon dilation for frontal
+is an agger nasi cell, get a `<strong>45 or 70 degree scope`</strong> and
+take down `<u>inferior`</u> part of agger nasi. `<u>Do not strip
+mucosa`</u>. A lot of people just do balloon dilation for frontal
 sinus
 </p>
 </li>
@@ -1034,5 +1034,5 @@ Have suction electrocautery and nasopores for hemostasis
 </ul>
 <!-- END Rhinology section -->
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/rotations.md
+++ b/rotations.md
@@ -3,17 +3,17 @@ layout: default
 title: Rotations
 ---
 <p>
-`<img alt="" src="media/image34.emf" style="width:6.02733in;height:3.12742in" />`{=html}
+`<img alt="" src="media/image34.emf" style="width:6.02733in;height:3.12742in" />
 </p>
 <p>
-`<img src="media/image35.jpeg" style="width:6.19954in;height:2.96273in" alt="C:\Users\jharb\Downloads\SGS_sizingguide.jpg" />`{=html}
+`<img src="media/image35.jpeg" style="width:6.19954in;height:2.96273in" alt="C:\Users\jharb\Downloads\SGS_sizingguide.jpg" />
 </p>
 <h1 class="unnumbered" id="antibiotic-coverage">
 Antibiotic Coverage
 </h1>
 <p>
-`<img alt="" src="media/image36.png" style="width:5.96171in;height:3.23186in" />`{=html}
+`<img alt="" src="media/image36.png" style="width:5.96171in;height:3.23186in" />
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/rules-of-the-game.md
+++ b/rules-of-the-game.md
@@ -4,9 +4,9 @@ title: Rules of the Game
 ---
 <p align="center" class="MsoNormal" style="text-align:center;mso-pagination:none;
 mso-layout-grid-align:none;">
-`<b>`{=html}[]{style="font-size:8.0pt;
+`<b>[]{style="font-size:8.0pt;
 mso-ascii-font-family:Calibri;mso-fareast-font-family:\"Times New Roman\";
-mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"}`</b>`{=html}
+mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"}`</b>
 </p>
 <p class="MsoNormal" style="mso-pagination:none;mso-layout-grid-align:none;
 <span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
@@ -16,82 +16,82 @@ residency is avoiding<b> phone calls </b>and</span><b><span style='font-family:
 mso-bidi-font-family:"Calibri\,Times New Roman"'> </span></b><span style="mso-ascii-font-family:Calibri;mso-fareast-font-family:Calibri;
 mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri">avoiding<b> pages</b></span><b><span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
 "Calibri\,Times New Roman";mso-bidi-font-family:"Calibri\,Times New Roman"'></span></b></p>
-`<b>`{=html}[]{style="mso-bidi-font-size:7.0pt;mso-ascii-font-family:
+`<b>[]{style="mso-bidi-font-size:7.0pt;mso-ascii-font-family:
 Calibri;mso-fareast-font-family:\"Times New Roman\";mso-hansi-font-family:Calibri;
-mso-bidi-font-family:Calibri"}`</b>`{=html}
+mso-bidi-font-family:Calibri"}`</b>
 </p>
-`<b>`{=html}Build your differential`</b>`{=html}: mistakes happen when you
-prematurely close on a diagnosis. R/O the worst-case scenarios`<b>`{=html}\<span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
-`<b>`{=html}[Never make
+`<b>Build your differential`</b>: mistakes happen when you
+prematurely close on a diagnosis. R/O the worst-case scenarios`<b>\<span style='font-family:"Calibri,Times New Roman",serif;mso-fareast-font-family:
+`<b>[Never make
 assumptions. ]{style="mso-ascii-font-family:Calibri;mso-fareast-font-family:
-Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"}`</b>`{=html}`<b>`{=html}[]{style="font-family:\"Calibri,Times New Roman\",serif;
-mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:\"Calibri\\,Times New Roman\""}`</b>`{=html}
+Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"}`</b>`<b>[]{style="font-family:\"Calibri,Times New Roman\",serif;
+mso-fareast-font-family:\"Calibri\\,Times New Roman\";mso-bidi-font-family:\"Calibri\\,Times New Roman\""}`</b>
 </p>
-Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"\>If you `<b>`{=html}delegate
-work,`</b>`{=html} you are still responsible for following up on the result`</span>`{=html}[]{style="font-family:\"Calibri,Times New Roman\",serif;mso-fareast-font-family:
+Calibri;mso-hansi-font-family:Calibri;mso-bidi-font-family:Calibri"\>If you `<b>delegate
+work,`</b> you are still responsible for following up on the result`</span>[]{style="font-family:\"Calibri,Times New Roman\",serif;mso-fareast-font-family:
 \"Calibri\\,Times New Roman\";mso-bidi-font-family:\"Calibri\\,Times New Roman\""}
 </p>
 []{style="mso-bidi-font-size:7.0pt;mso-ascii-font-family:
 mso-bidi-font-family:Calibri;mso-bidi-font-weight:bold"}
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Escalate `</b>`{=html}any clinical changes in a patient to a
+`<b>Escalate `</b>any clinical changes in a patient to a
 senior resident or attending. This is not just to CYA but to avoid mistakes.
 Two eyes are better than one
 </p>
 <p class="MsoNormal">
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Text out`</b>`{=html} to the other residents for any consults, new
+`<b>Text out`</b> to the other residents for any consults, new
 ED or post-op admissions.
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Everyone's time is valuable`</b>`{=html}. No matter what level of
+`<b>Everyone's time is valuable`</b>. No matter what level of
 training you are, no job is above or beneath you. Don't ask others to do your
 busy work. No-one is going to clean up your mess.
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Help the PGY-2`</b>`{=html}. It's a small service so if anyone
+`<b>Help the PGY-2`</b>. It's a small service so if anyone
 isn't pulling their weight things fall apart.[ 
 ]{style="mso-spacerun:yes"}We are our own checks and balances.
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Teach`</b>`{=html}-- you have an obligation to pass on your
+`<b>Teach`</b>-- you have an obligation to pass on your
 knowledge to the residents, interns, and medical students under you. If you
 present, make sure you give people 3-4 take away points.
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Be prepared for every case `</b>`{=html}-- pretend there is no
+`<b>Be prepared for every case `</b>-- pretend there is no
 attending with you.
 </p>
 <p class="MsoNormal">
-When you present to an attending, give `<b>`{=html}just the meat`</b>`{=html}
+When you present to an attending, give `<b>just the meat`</b>
 -- tell them what symptoms the patient has before telling them what the patient
-doesn't have`<b>`{=html}. `</b>`{=html}
+doesn't have`<b>. `</b>
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Don't miss didactics.`</b>`{=html} The service as a team must
+`<b>Don't miss didactics.`</b> The service as a team must
 protect this time.
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Temporal bones don't drill themselves `</b>`{=html}-- but they want
+`<b>Temporal bones don't drill themselves `</b>-- but they want
 to be drilled. Keep the temporal bone lab in good working order and harvest
 bones in the Spring
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Treat every day like a job interview`</b>`{=html} -- The attendings
+`<b>Treat every day like a job interview`</b> -- The attendings
 notice when you work hard and when you slack off. Ultimately, their opinion of
 you dictates your ability to get a job/match into a fellowship after
 residency.[  ]{style="mso-spacerun:yes"}
 </p>
 <p class="MsoNormal">
-`<b>`{=html}Update the guide`</b>`{=html}: every time you think "this would be
+`<b>Update the guide`</b>: every time you think "this would be
 useful for the pocketbook," add it in. This doesn't update itself.
 </p>
 <p class="MsoNormal">
-Try and `<b>`{=html}improve every aspect of our program`</b>`{=html}. Everyone
+Try and `<b>improve every aspect of our program`</b>. Everyone
 has to do their bit to leave this program better off than when you came.
 </p>
 <p>
-`<a href='index.html'>`{=html}Back to homepage`</a>`{=html}
+`<a href='index.html'>Back to homepage`</a>
 </p>

--- a/templates-protocols.md
+++ b/templates-protocols.md
@@ -9,23 +9,23 @@ Templates/Protocols
 Click to access (electronic version):
 </p>
 <p>
-`<a href="https://1drv.ms/f/s!AgoNMr1jv4esgtB_XesPkzDNWmAYbw">`{=html}Consent templates`</a>`{=html}
+`<a href="https://1drv.ms/f/s!AgoNMr1jv4esgtB_XesPkzDNWmAYbw">Consent templates`</a>
 </p>
 <p>
-`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgtB-EB_yGrmtyULstQ">`{=html}Discharge instructions`</a>`{=html}
+`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgtB-EB_yGrmtyULstQ">Discharge instructions`</a>
 </p>
 <p>
-`<a href="https://1drv.ms/b/s!AgoNMr1jv4esgbMvDI7FAwrYUtDQVg">`{=html}Discharge Instructions for Inspire Implant`</a>`{=html}
+`<a href="https://1drv.ms/b/s!AgoNMr1jv4esgbMvDI7FAwrYUtDQVg">Discharge Instructions for Inspire Implant`</a>
 </p>
 <p>
-`<a href="https://1drv.ms/p/s!AgoNMr1jv4esgsJGAXN7TbROeBe8jQ">`{=html}OR equipment list`</a>`{=html}
+`<a href="https://1drv.ms/p/s!AgoNMr1jv4esgsJGAXN7TbROeBe8jQ">OR equipment list`</a>
 </p>
 <p>
-`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgbon7kS9r1SFII1IPg">`{=html}MDO Handout and Log`</a>`{=html}
+`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgbon7kS9r1SFII1IPg">MDO Handout and Log`</a>
 </p>
 <p>
-`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgsJIEtgeKz9gNRBggA">`{=html}Resident Approval Forms for Conferences`</a>`{=html}
+`<a href="https://1drv.ms/w/s!AgoNMr1jv4esgsJIEtgeKz9gNRBggA">Resident Approval Forms for Conferences`</a>
 </p>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/tips.md
+++ b/tips.md
@@ -6,72 +6,72 @@ title: Tips
 Tips
 </h1>
 <p>
-`<strong>`{=html}EMR:`</strong>`{=html}
+`<strong>EMR:`</strong>
 </p>
 <p>
 Epic for desktop and Haiku for mobile platforms
 </p>
 <p>
-`<strong>`{=html}Links:`</strong>`{=html}
+`<strong>Links:`</strong>
 </p>
 <p>
-Tufts Intranet URL:`<a href="http://intranet.nemc.org/">`{=html}http://intranet.nemc.org/`</a>`{=html}
+Tufts Intranet URL:`<a href="http://intranet.nemc.org/">http://intranet.nemc.org/`</a>
 </p>
 <p>
 Paging URL:`<a href="http://neamcomweb.tufts-
-nemc.org/smartweb/pages/directory/PersonSearchResults.jsf">`{=html}http://neamcomweb.tufts-
-nemc.org/smartweb/pages/directory/PersonSearchResults.jsf`</a>`{=html}
+nemc.org/smartweb/pages/directory/PersonSearchResults.jsf">http://neamcomweb.tufts-
+nemc.org/smartweb/pages/directory/PersonSearchResults.jsf`</a>
 </p>
 <p>
 Citrix Receiver: https://access.well-net.org/Citrix/WellforceWeb/
 </p>
 <hr />
 <p>
-`<strong>`{=html}Radiology`</strong>`{=html}
+`<strong>Radiology`</strong>
 </p>
 <p>
-`<strong>`{=html}Access PACS from home`</strong>`{=html} Log on to the VPN and go to `<a href="http://radlink.tufts-nemc.org/">`{=html}http://radlink.tufts-nemc.org/`</a>`{=html}
+`<strong>Access PACS from home`</strong> Log on to the VPN and go to `<a href="http://radlink.tufts-nemc.org/">http://radlink.tufts-nemc.org/`</a>
 </p>
 <p>
-`<strong>`{=html}Access Vue motion`</strong>`{=html} : `<a href="http://10.138.132.14/">`{=html}http://10.138.132.14/`</a>`{=html}
+`<strong>Access Vue motion`</strong> : `<a href="http://10.138.132.14/">http://10.138.132.14/`</a>
 </p>
 <p>
-`<strong>`{=html}PACS`</strong>`{=html} (PC and internet explorer only): `<a href="http://155.36.152.94/">`{=html}http://155.36.152.94/`</a>`{=html}
+`<strong>PACS`</strong> (PC and internet explorer only): `<a href="http://155.36.152.94/">http://155.36.152.94/`</a>
 </p>
 <p>
-`<strong>`{=html}CT wet reads`</strong>`{=html} from radiology resident (proger 4).
+`<strong>CT wet reads`</strong> from radiology resident (proger 4).
 </p>
 <p>
-`<strong>`{=html}OSH Imaging reads:`</strong>`{=html} read request form in North 4 charting room, clarify which images want read
+`<strong>OSH Imaging reads:`</strong> read request form in North 4 charting room, clarify which images want read
 and hand deliver form to radiologist
 </p>
 <p>
-`<strong>`{=html}IR:`</strong>`{=html} order in Epic, call after 7 to book and discuss.
+`<strong>IR:`</strong> order in Epic, call after 7 to book and discuss.
 </p>
 <p>
-`<strong>`{=html}Phlebotomy times:`</strong>`{=html} 1, 5AM, 1,5,7,9,11 PM. Page if it's timed or urgent; notify nursing if
+`<strong>Phlebotomy times:`</strong> 1, 5AM, 1,5,7,9,11 PM. Page if it's timed or urgent; notify nursing if
 they have a PICC/Central line. If STAT, use "now" order, draw them yourself, label, bag, and tube to
 the lab.
 </p>
 <p>
-`<strong>`{=html}XR STAT:`</strong>`{=html} Order in Epic, page 1208 with patient name, location, image, indication
+`<strong>XR STAT:`</strong> Order in Epic, page 1208 with patient name, location, image, indication
 </p>
 <p>
-`<strong>`{=html}MRI screening forms:`</strong>`{=html} done by nursing, unless you need it STAT(do it yourself)
+`<strong>MRI screening forms:`</strong> done by nursing, unless you need it STAT(do it yourself)
 </p>
 <p>
-`<strong>`{=html}PICC`</strong>`{=html} : Consent form in Epic- print, get it signed, and fax before placing order. Requires
+`<strong>PICC`</strong> : Consent form in Epic- print, get it signed, and fax before placing order. Requires
 recent PT/PTT/platelet/Cr
 </p>
 <p>
-`<strong>`{=html}Central line removal form:`</strong>`{=html} Must be done for every line pull, requires an observer (RN or
+`<strong>Central line removal form:`</strong> Must be done for every line pull, requires an observer (RN or
 MD), put in procedures section of chart
 </p>
 <p>
-`<strong>`{=html}Add on labs:`</strong>`{=html} in Epic, lab order \> add to last collection
+`<strong>Add on labs:`</strong> in Epic, lab order \> add to last collection
 </p>
 <p>
-`<strong>`{=html}Pager forwarding:`</strong>`{=html} Paging system\>personal profile\> login/pw is pager number \> Status/Exceptions\>
+`<strong>Pager forwarding:`</strong> Paging system\>personal profile\> login/pw is pager number \> Status/Exceptions\>
 Add new exception \> Coverage \> New; Put start and end date
 </p>
 <ul>
@@ -85,5 +85,5 @@ Don't forget to forward your pager when you're on vacation
 </p>
 </ul>
 <p>
-`<a href="index.html">`{=html}Back to homepage`</a>`{=html}
+`<a href="index.html">Back to homepage`</a>
 </p>

--- a/weekly-routines.md
+++ b/weekly-routines.md
@@ -3,10 +3,10 @@ layout: default
 title: Weekly Routines
 ---
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Monday`</b>`{=html}: [ ]{style="mso-tab-count:1"}PGY-2 sends out final radiology rounds list
+`<b>Monday`</b>: [ ]{style="mso-tab-count:1"}PGY-2 sends out final radiology rounds list
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Tuesday`</b>`{=html}:[  ]{style="mso-tab-count:1"}
+`<b>Tuesday`</b>:[  ]{style="mso-tab-count:1"}
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:.2in">
 Attending on-call
@@ -17,7 +17,7 @@ PGY-4 reminds
 on-call attending re mock orals the next day)
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Wednesday`</b>`{=html}
+`<b>Wednesday`</b>
 (didactic day)
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
@@ -46,26 +46,26 @@ run by PGY-4 or PGY-5
 [       ]{style="mso-tab-count:1"}4-6pm: Didactics
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Thursday`</b>`{=html}
+`<b>Thursday`</b>
 (8:30am OR start): 7:00-8am: Article review (led by PGY-4/PGY-5)
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Friday`</b>`{=html}:
+`<b>Friday`</b>:
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:.1in">
 PGY-5 e-mails out
 weekly schedule.[  ]{style="mso-spacerun:yes"}
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Saturday`</b>`{=html}:
+`<b>Saturday`</b>:
 nothing
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
-`<b>`{=html}Sunday`</b>`{=html}: PGY-2
+`<b>Sunday`</b>: PGY-2
 sends out prelim radiology rounds list
 </p>
 <p class="MsoNormal" style="margin-left:0in;text-indent:0in">
 </p>
 <p>
-`<a href='index.html'>`{=html}Back to homepage`</a>`{=html}
+`<a href='index.html'>Back to homepage`</a>
 </p>

--- a/yearly-routines.md
+++ b/yearly-routines.md
@@ -9,36 +9,36 @@ These are the things that we need to make sure happen.
 mso-list:l115 level1 lfo60">
 <!--[if !supportLists]-->
 [[I[   ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin"}`<!--[endif]-->`{=html}Temporal
+Calibri;mso-bidi-theme-font:minor-latin"}`<!--[endif]-->Temporal
 Bone Lab:
 </p>
 <p class="MsoListParagraphCxSpMiddle" style="margin-left:.4in;mso-add-space:auto;
 mso-list:l115 level2 lfo60">
 <!--[if !supportLists]-->
 [[A[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}]{style="mso-bidi-font-family:
-Calibri;mso-bidi-theme-font:minor-latin"}`<!--[endif]-->`{=html}Obtain
+Calibri;mso-bidi-theme-font:minor-latin"}`<!--[endif]-->Obtain
 a copy of the House Dissector Manuel for Temporal Bone Lab
 </p>
-Calibri;mso-bidi-theme-font:minor-latin"\>[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`{=html}`<!--[endif]-->`{=html}Make
+Calibri;mso-bidi-theme-font:minor-latin"\>[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`<!--[endif]-->Make
 sure every resident has a key to the temporal bone lab
 </p>
-Calibri;mso-bidi-theme-font:minor-latin"\>[C[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`{=html}`<!--[endif]-->`{=html}In
+Calibri;mso-bidi-theme-font:minor-latin"\>[C[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`<!--[endif]-->In
 mid/late March -- speak to the Anatomy lab and ask when we can harvest temporal
 bones and go with Dr. Sillman to Harvest them
 </p>
 <p class="MsoListParagraphCxSpMiddle" style="margin-left:.2in;mso-add-space:auto;
 Calibri;mso-bidi-theme-font:minor-latin">
-[II[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`{=html}`<!--[endif]-->`{=html}Self-Study
+[II[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`<!--[endif]-->Self-Study
 </p>
-Calibri;mso-bidi-theme-font:minor-latin"\>[A[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`{=html}`<!--[endif]-->`{=html}Make
+Calibri;mso-bidi-theme-font:minor-latin"\>[A[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`<!--[endif]-->Make
 sure we have access to the Home Study Course (Go to AcademyU.org and sign in
 with your AAO-HNS login and access HSC Plus)
 </p>
 <p class="MsoListParagraphCxSpLast" style="margin-left:.4in;mso-add-space:auto;
 Calibri;mso-bidi-theme-font:minor-latin">
-[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`{=html}`<!--[endif]-->`{=html}Obtain
+[B[  ]{style="font:7.0pt \"Times New Roman\""}]{style="mso-list:Ignore"}`</span>`<!--[endif]-->Obtain
 access to the [boardvitals]{.SpellE} website for questions
 </p>
 <p>
-`<a href='index.html'>`{=html}Back to homepage`</a>`{=html}
+`<a href='index.html'>Back to homepage`</a>
 </p>


### PR DESCRIPTION
## Summary
- removed `{=html}` artifacts left over in markdown files

## Testing
- `grep -R "{=html}" -n`

------
https://chatgpt.com/codex/tasks/task_e_688be290a140832f9e23f4b1141dfb29