### PR TITLE
Add batch markdown conversion to clean_html script

### DIFF
--- a/clean_html.py
+++ b/clean_html.py
@@ -1,4 +1,7 @@
-import sys, re, pathlib
+import sys
+import re
+import pathlib
+import subprocess
 
 substitutions = [
     (re.compile(r'<p[^>]*>', re.I), ''),
@@ -74,6 +77,17 @@ def process_file(path):
     cleaned = clean_text(body)
     path.write_text(front + cleaned, encoding='utf-8')
 
+def main():
+    args = sys.argv[1:]
+    if args:
+        paths = [pathlib.Path(p) for p in args]
+    else:
+        repo_root = pathlib.Path(__file__).resolve().parent
+        result = subprocess.check_output(['git', 'ls-files', '*.md'], text=True)
+        paths = [repo_root / p for p in result.strip().splitlines() if p]
+    for path in paths:
+        process_file(path)
+
+
 if __name__ == '__main__':
-    for file in sys.argv[1:]:
-        process_file(pathlib.Path(file))
+    main()


### PR DESCRIPTION
## Summary
- allow `clean_html.py` to process a list of markdown files or the entire repo when no args are given

## Testing
- `python -m py_compile clean_html.py`
- `python clean_html.py` *(executed in a separate copy of the repo)*

------
https://chatgpt.com/codex/tasks/task_e_688e470d9038832fa8a75bcfdc5671f7