### PR TITLE
Remove header boxes and underline headings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,6 +33,19 @@ header h1 {
   box-sizing: border-box;
 }
 
+/* Subtle underline for headings */
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  border: none;
+  background: none;
+  padding: 0 0 0.25em;
+  border-bottom: 1px solid #ddd;
+}
+
 /* Collapsible headings */
 .collapsible {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Remove box styling from markdown headings and replace with a light underline

## Testing
- `npx --yes prettier --check "css/style.css"` *(reports formatting differences)*
- `npx --yes csslint css/style.css` *(reports 31 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e7df0045c832fa403c7054772ee1d