### PR TITLE
Render pages with GitHub Markdown API

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,38 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>{{ page.title }}</title>
-</head>
-<body>
-<pre>{{ page.content | escape }}</pre>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ page.title }}</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
+    />
+  </head>
+  <body>
+    <textarea id="markdown-src" style="display: none">
+{{ page.content | escape }}</textarea
+    >
+    <article id="content" class="markdown-body"></article>
+    <script>
+      (async () => {
+        const src = document.getElementById("markdown-src");
+        const content = document.getElementById("content");
+        const md = src.value;
+        try {
+          const resp = await fetch("https://api.github.com/markdown", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/vnd.github+json",
+            },
+            body: JSON.stringify({ text: md }),
+          });
+          const html = await resp.text();
+          content.innerHTML = html;
+        } catch (e) {
+          content.textContent = md;
+        }
+      })();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Use GitHub Markdown API to render page content
- Apply GitHub's markdown CSS for consistent styling

## Testing
- `npx prettier -w _layouts/default.html`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_688e8cdaa644832faf74c3393db092f4