### PR TITLE
Add bottom navigation bar with search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,12 +7,61 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
     />
+    <style>
+      #bottom-bar {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(255, 255, 255, 0.9);
+        border-top: 1px solid #ccc;
+        font-family: sans-serif;
+      }
+      #bottom-bar input[type="search"] {
+        flex: 1;
+        padding: 0.25rem;
+      }
+      #search-results {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 2.5rem;
+        max-height: 40vh;
+        overflow-y: auto;
+        background: #fff;
+        border-top: 1px solid #ccc;
+        display: none;
+        padding: 0.5rem;
+        font-family: sans-serif;
+      }
+      #search-results ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      #search-results li {
+        margin: 0.25rem 0;
+      }
+      #search-results a {
+        text-decoration: none;
+      }
+    </style>
   </head>
   <body>
     <textarea id="markdown-src" style="display: none">
 {{ page.content | escape }}</textarea
     >
     <article id="content" class="markdown-body"></article>
+    <div id="bottom-bar">
+      <button id="back-button" title="Back">&#8592;</button>
+      <a id="home-button" title="Home" href="{{ '/' | relative_url }}">&#8962;</a>
+      <input type="search" id="search-input" placeholder="Search..." />
+    </div>
+    <div id="search-results"></div>
     <script>
       (async () => {
         const src = document.getElementById("markdown-src");
@@ -34,5 +83,6 @@
         }
       })();
     </script>
+    <script src="{{ '/menu.js' | relative_url }}"></script>
   </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,113 @@
+const pages = [
+  'antibiogram.html',
+  'cranial-nerves.html',
+  'daily-routine.html',
+  'facial-plastics.html',
+  'facial-trauma-guide.html',
+  'head-and-neck-surgery.html',
+  'index.html',
+  'laryngology.html',
+  'levels-of-the-neck.html',
+  'local-rotational-flaps.html',
+  'map-of-tufts-medical-center.html',
+  'medications.html',
+  'monthly-routines.html',
+  'on-call-guide.html',
+  'or-instruments.html',
+  'orders-discharges-and-dictations.html',
+  'otolaryngology-national-conference-schedule.html',
+  'otology.html',
+  'pediatric-otolaryngology.html',
+  'perioperative-aspirin-anticoagulation-guide.html',
+  'radiology-levels-of-the-neck.html',
+  'review-of-systems.html',
+  'rhinology.html',
+  'rotations.html',
+  'rules-of-the-game.html',
+  'templates-protocols.html',
+  'tips.html',
+  'weekly-routines.html',
+  'yearly-routines.html'
+];
+
+async function searchSite(query) {
+  const results = [];
+  const lower = query.toLowerCase();
+  for (const url of pages) {
+    try {
+      const resp = await fetch(url);
+      const text = await resp.text();
+      const plain = text.replace(/<[^>]*>/g, ' ');
+      const idx = plain.toLowerCase().indexOf(lower);
+      if (idx !== -1) {
+        const titleMatch = text.match(/<title>(.*?)<\/title>/i);
+        const title = titleMatch ? titleMatch[1] : url;
+        const start = Math.max(0, idx - 40);
+        const end = Math.min(plain.length, idx + query.length + 40);
+        let snippet = plain.slice(start, end).replace(/\s+/g, ' ').trim();
+        const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'i');
+        snippet = snippet.replace(regex, '<b>$1</b>');
+        const fragment = encodeURIComponent(plain.substr(idx, query.length));
+        results.push({ url, title, snippet, fragment });
+      }
+    } catch (e) {
+      // ignore errors
+    }
+  }
+  return results;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const backBtn = document.getElementById('back-button');
+  if (backBtn) {
+    backBtn.addEventListener('click', () => history.back());
+  }
+
+  const input = document.getElementById('search-input');
+  const resultsDiv = document.getElementById('search-results');
+
+  async function doSearch() {
+    const q = input.value.trim();
+    if (!q) {
+      resultsDiv.style.display = 'none';
+      resultsDiv.innerHTML = '';
+      return;
+    }
+    resultsDiv.style.display = 'block';
+    resultsDiv.innerHTML = 'Searching...';
+    const matches = await searchSite(q);
+    if (matches.length === 0) {
+      resultsDiv.innerHTML = '<div>No results found.</div>';
+      return;
+    }
+    const ul = document.createElement('ul');
+    for (const page of matches) {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = `${page.url}#:~:text=${page.fragment}`;
+      a.textContent = page.title;
+      const snippet = document.createElement('span');
+      snippet.innerHTML = ` - ${page.snippet}`;
+      li.appendChild(a);
+      li.appendChild(snippet);
+      ul.appendChild(li);
+    }
+    resultsDiv.innerHTML = '';
+    resultsDiv.appendChild(ul);
+  }
+
+  if (input) {
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        doSearch();
+      }
+    });
+  }
+
+  document.addEventListener('click', (e) => {
+    const bar = document.getElementById('bottom-bar');
+    if (!bar.contains(e.target) && !resultsDiv.contains(e.target)) {
+      resultsDiv.style.display = 'none';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add fixed bottom navigation bar with back, home and search controls
- implement site-wide search that shows snippet matches and deep links

## Testing
- `node --check menu.js`


------
https://chatgpt.com/codex/tasks/task_e_688e93e883a4832fb8509a915dc46c20