### PR TITLE
Add site padding and enlarge bottom menu bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,12 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
     />
     <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        padding-bottom: 4rem;
+        box-sizing: border-box;
+      }
       #bottom-bar {
         position: fixed;
         left: 0;
@@ -16,20 +22,21 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        padding: 0.25rem 0.5rem;
+        padding: 0.75rem 1rem;
         background: rgba(255, 255, 255, 0.9);
         border-top: 1px solid #ccc;
         font-family: sans-serif;
+        font-size: 1.2rem;
       }
       #bottom-bar input[type="search"] {
         flex: 1;
-        padding: 0.25rem;
+        padding: 0.5rem;
       }
       #search-results {
         position: fixed;
         left: 0;
         right: 0;
-        bottom: 2.5rem;
+        bottom: 4rem;
         max-height: 40vh;
         overflow-y: auto;
         background: #fff;


### PR DESCRIPTION
## Summary
- add global body padding and bottom spacing to keep content off edges
- enlarge bottom bar and search box so it doesn't cover page text
- shift search results above taller menu bar

## Testing
- `python -m py_compile clean_html.py convert_to_pure_markdown.py`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e96ea2be4832fbf9cfc87c3f5fb69