### PR TITLE
Enable collapsible headings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,6 +56,15 @@
       #search-results a {
         text-decoration: none;
       }
+      .collapsible {
+        cursor: pointer;
+      }
+      .collapsible::after {
+        content: " \25BE";
+      }
+      .collapsible.collapsed::after {
+        content: " \25B8";
+      }
     </style>
   </head>
   <body>
@@ -65,7 +74,9 @@
     <article id="content" class="markdown-body"></article>
     <div id="bottom-bar">
       <button id="back-button" title="Back">&#8592;</button>
-      <a id="home-button" title="Home" href="{{ '/' | relative_url }}">&#8962;</a>
+      <a id="home-button" title="Home" href="{{ '/' | relative_url }}"
+        >&#8962;</a
+      >
       <input type="search" id="search-input" placeholder="Search..." />
     </div>
     <div id="search-results"></div>
@@ -91,5 +102,6 @@
       })();
     </script>
     <script src="{{ '/menu.js' | relative_url }}"></script>
+    <script src="{{ '/site.js' | relative_url }}"></script>
   </body>
 </html>

--- a/site.js
+++ b/site.js
@@ -1,40 +1,46 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const header = document.querySelector('header');
+document.addEventListener("DOMContentLoaded", () => {
+  const header = document.querySelector("header");
   if (header) {
     const threshold = 50;
     const onScroll = () => {
       if (window.scrollY > threshold) {
-        header.classList.add('collapsed');
+        header.classList.add("collapsed");
       } else {
-        header.classList.remove('collapsed');
+        header.classList.remove("collapsed");
       }
     };
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener("scroll", onScroll);
     onScroll();
   }
 
   // Make headings collapsible
-  const main = document.querySelector('main');
+  const main = document.querySelector("main, #content");
   if (main) {
-    const headings = main.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const headings = main.querySelectorAll("h1, h2, h3, h4, h5, h6");
     headings.forEach((heading) => {
       const level = parseInt(heading.tagName.substring(1));
       const section = [];
       let el = heading.nextElementSibling;
-      while (el && !(el.tagName.match(/^H[1-6]$/) && parseInt(el.tagName.substring(1)) <= level)) {
+      while (
+        el &&
+        !(
+          el.tagName.match(/^H[1-6]$/) &&
+          parseInt(el.tagName.substring(1)) <= level
+        )
+      ) {
         section.push(el);
         el = el.nextElementSibling;
       }
       if (section.length) {
-        const wrapper = document.createElement('div');
-        wrapper.classList.add('collapsible-content');
+        const wrapper = document.createElement("div");
+        wrapper.classList.add("collapsible-content");
         section.forEach((node) => wrapper.appendChild(node));
-        heading.insertAdjacentElement('afterend', wrapper);
-        heading.classList.add('collapsible');
-        heading.addEventListener('click', () => {
-          const hidden = wrapper.style.display === 'none';
-          wrapper.style.display = hidden ? '' : 'none';
-          heading.classList.toggle('collapsed', !hidden);
+        heading.insertAdjacentElement("afterend", wrapper);
+        heading.classList.add("collapsible");
+        heading.addEventListener("click", () => {
+          const hidden = wrapper.style.display === "none";
+          wrapper.style.display = hidden ? "" : "none";
+          heading.classList.toggle("collapsed", !hidden);
         });
       }
     });


### PR DESCRIPTION
## Summary
- include `site.js` on every page and add minimal styles for collapsible headers
- look for `main` or `#content` container so heading sections can be toggled

## Testing
- `npx prettier -c site.js _layouts/default.html`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9b7263a8832f937df5d6e4087458