### PR TITLE
Add left-side caret for collapsible headings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,11 +59,14 @@
       .collapsible {
         cursor: pointer;
       }
-      .collapsible::after {
-        content: " \25BE";
+      .collapsible::before {
+        content: "\25BE";
+        display: inline-block;
+        margin-right: 0.25em;
+        font-size: 0.8em;
       }
-      .collapsible.collapsed::after {
-        content: " \25B8";
+      .collapsible.collapsed::before {
+        content: "\25B8";
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- show a small left-side caret for expandable sections

## Testing
- `node --check site.js`


------
https://chatgpt.com/codex/tasks/task_e_688e9fe31e0c832fa3aaa3d188c571fe