### PR TITLE
Improve mobile usability

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ page.title }}</title>
     <link
       rel="stylesheet"
@@ -41,6 +42,7 @@
       #bottom-bar input[type="search"] {
         flex: 1;
         padding: 0.5rem;
+        font-size: 1em;
       }
       #search-results {
         position: fixed;
@@ -77,6 +79,23 @@
       }
       .collapsible.collapsed::before {
         content: "\25B8";
+      }
+      @media (max-width: 600px) {
+        body {
+          font-size: 18px;
+          padding-bottom: 6rem;
+        }
+        #bottom-bar {
+          font-size: 1.4rem;
+          padding: 1rem 1.25rem;
+        }
+        #bottom-bar button,
+        #bottom-bar a {
+          font-size: 2.2rem;
+        }
+        #bottom-bar input[type="search"] {
+          padding: 0.75rem;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper mobile scaling
- enlarge fonts and bottom bar on small screens
- ensure search input font is large enough to prevent zoom

## Testing
- `npx prettier _layouts/default.html --check`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ea2bf9048832fb7017576bdd9499b