### PR TITLE
Add collapsible icons for collapsible headings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -70,15 +70,12 @@
       }
       .collapsible {
         cursor: pointer;
+        display: flex;
+        align-items: center;
       }
-      .collapsible::before {
-        content: "\25BE";
-        display: inline-block;
+      .collapse-icon {
         margin-right: 0.25em;
         font-size: 0.8em;
-      }
-      .collapsible.collapsed::before {
-        content: "\25B8";
       }
       @media (max-width: 600px) {
         body {

--- a/site.js
+++ b/site.js
@@ -37,11 +37,24 @@ document.addEventListener("DOMContentLoaded", () => {
         section.forEach((node) => wrapper.appendChild(node));
         heading.insertAdjacentElement("afterend", wrapper);
         heading.classList.add("collapsible");
-        heading.addEventListener("click", () => {
+
+        const icon = document.createElement("span");
+        icon.classList.add("collapse-icon");
+        icon.textContent = "\u25BE";
+        heading.insertBefore(icon, heading.firstChild);
+
+        const toggle = () => {
           const hidden = wrapper.style.display === "none";
           wrapper.style.display = hidden ? "" : "none";
           heading.classList.toggle("collapsed", !hidden);
+          icon.textContent = hidden ? "\u25BE" : "\u25B8";
+        };
+
+        icon.addEventListener("click", (e) => {
+          e.stopPropagation();
+          toggle();
         });
+        heading.addEventListener("click", toggle);
       }
     });
   }


### PR DESCRIPTION
## Summary
- insert interactive arrow icons before headings to control collapsible sections
- add CSS for new collapse icons and remove pseudo-element approach

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ea92cebbc832fbbb375a8a88bffc9