### PR TITLE
Expand otology pages and overhaul search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,29 +44,50 @@
         padding: 0.5rem;
         font-size: 1em;
       }
-      #search-results {
+      #search-overlay {
         position: fixed;
+        top: 0;
         left: 0;
         right: 0;
-        bottom: 4rem;
-        max-height: 40vh;
-        overflow-y: auto;
+        bottom: 0;
         background: #fff;
-        border-top: 1px solid #ccc;
         display: none;
+        flex-direction: column;
+        z-index: 1000;
+      }
+      #search-overlay-header {
+        display: flex;
+        align-items: center;
         padding: 0.5rem;
+        border-bottom: 1px solid #ccc;
+        gap: 0.5rem;
+      }
+      #search-overlay-header input[type="search"] {
+        flex: 1;
+        padding: 0.5rem;
+        font-size: 1em;
+      }
+      #search-overlay-results {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0.5rem 1rem;
         font-family: sans-serif;
       }
-      #search-results ul {
+      #search-overlay-results ul {
         list-style: none;
         margin: 0;
         padding: 0;
       }
-      #search-results li {
-        margin: 0.25rem 0;
+      #search-overlay-results li {
+        margin: 0.5rem 0;
       }
-      #search-results a {
+      #search-overlay-results a {
         text-decoration: none;
+      }
+      #search-close {
+        font-size: 1.5rem;
+        background: none;
+        border: none;
       }
       .collapsible {
         cursor: pointer;
@@ -111,7 +132,17 @@
       >
       <input type="search" id="search-input" placeholder="Search..." />
     </div>
-    <div id="search-results"></div>
+    <div id="search-overlay">
+      <div id="search-overlay-header">
+        <input
+          type="search"
+          id="search-overlay-input"
+          placeholder="Search..."
+        />
+        <button id="search-close" title="Close">&times;</button>
+      </div>
+      <div id="search-overlay-results"></div>
+    </div>
     <script>
       (async () => {
         const src = document.getElementById("markdown-src");

--- a/index.md
+++ b/index.md
@@ -45,11 +45,23 @@ title: Home
 
 - [Clinic Guide](otology/clinic-guide.html)
 
+- [Facial Nerve](otology/facial-nerve.html)
+
 - [Neuro-otology Imaging](otology/neuro-otology-imaging.html)
 
 - [Otitis](otology/otitis.html)
 
 - [OR Guide](otology/or-guide.html)
+
+- [Otosclerosis](otology/otosclerosis.html)
+
+- [Temporal Bone Lab](otology/temporal-bone-lab.html)
+
+- [The Cranial Nerves](otology/the-cranial-nerves.html)
+
+- [Tinnitus](otology/tinnitus.html)
+
+- [Vertigo](otology/vertigo.html)
 
 [Facial Plastics](facial-plastics.html)
 

--- a/menu.js
+++ b/menu.js
@@ -12,6 +12,36 @@ async function getPages() {
   return cachedPages;
 }
 
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function fetchPage(url) {
+  const resp = await fetch(url);
+  const text = await resp.text();
+  const titleMatch = text.match(/<title>(.*?)<\/title>/i);
+  const title = titleMatch ? titleMatch[1] : url;
+  const mdMatch = text.match(
+    /<textarea id="markdown-src"[^>]*>([\s\S]*?)<\/textarea>/i
+  );
+  const md = mdMatch ? mdMatch[1] : '';
+  let html = md;
+  try {
+    const mdResp = await fetch('https://api.github.com/markdown', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({ text: md }),
+    });
+    html = await mdResp.text();
+  } catch (e) {
+    html = md;
+  }
+  return { title, html };
+}
+
 async function searchSite(query) {
   const results = [];
   const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
@@ -19,25 +49,28 @@ async function searchSite(query) {
   for (const url of pages) {
     try {
       const pageUrl = '/' + url;
-      const resp = await fetch(pageUrl);
-      const text = await resp.text();
-      const plain = text.replace(/<[^>]*>/g, ' ');
-      const lower = plain.toLowerCase();
-      const matches = terms.every(t => lower.includes(t));
-      if (matches) {
-        const idx = lower.indexOf(terms[0]);
-        const titleMatch = text.match(/<title>(.*?)<\/title>/i);
-        const title = titleMatch ? titleMatch[1] : pageUrl;
-        const start = Math.max(0, idx - 40);
-        const end = Math.min(plain.length, idx + terms[0].length + 40);
-        let snippet = plain.slice(start, end).replace(/\s+/g, ' ').trim();
-        for (const term of terms) {
-          const regex = new RegExp(`(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'ig');
-          snippet = snippet.replace(regex, '<b>$1</b>');
+      const { title, html } = await fetchPage(pageUrl);
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const bodyText = doc.body.textContent.toLowerCase();
+      if (!terms.every((t) => bodyText.includes(t))) continue;
+      let snippetEl = null;
+      for (const el of doc.querySelectorAll(
+        'p, li, h1, h2, h3, h4, h5, h6'
+      )) {
+        const text = el.textContent.toLowerCase();
+        if (terms.every((t) => text.includes(t))) {
+          snippetEl = el;
+          break;
         }
-        const fragment = encodeURIComponent(plain.substr(idx, terms[0].length));
-        results.push({ url: pageUrl, title, snippet, fragment });
       }
+      let snippetHtml = snippetEl ? snippetEl.innerHTML : '';
+      for (const term of terms) {
+        const regex = new RegExp(escapeRegExp(term), 'ig');
+        snippetHtml = snippetHtml.replace(regex, '<mark>$&</mark>');
+      }
+      const fragment = encodeURIComponent(terms[0]);
+      results.push({ url: pageUrl, title, snippet: snippetHtml, fragment });
     } catch (e) {
       // ignore errors
     }
@@ -51,21 +84,48 @@ document.addEventListener('DOMContentLoaded', () => {
     backBtn.addEventListener('click', () => history.back());
   }
 
-  const input = document.getElementById('search-input');
-  const resultsDiv = document.getElementById('search-results');
+  const openInput = document.getElementById('search-input');
+  const overlay = document.getElementById('search-overlay');
+  const overlayInput = document.getElementById('search-overlay-input');
+  const overlayResults = document.getElementById('search-overlay-results');
+  const closeBtn = document.getElementById('search-close');
+
+  function openSearch() {
+    overlay.style.display = 'flex';
+    overlayInput.value = '';
+    overlayResults.innerHTML = '';
+    overlayInput.focus();
+  }
+
+  function closeSearch() {
+    overlay.style.display = 'none';
+  }
+
+  if (openInput) {
+    openInput.addEventListener('focus', openSearch);
+    openInput.addEventListener('click', openSearch);
+  }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', closeSearch);
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay.style.display === 'flex') {
+      closeSearch();
+    }
+  });
 
   async function doSearch() {
-    const q = input.value.trim();
+    const q = overlayInput.value.trim();
     if (!q) {
-      resultsDiv.style.display = 'none';
-      resultsDiv.innerHTML = '';
+      overlayResults.innerHTML = '';
       return;
     }
-    resultsDiv.style.display = 'block';
-    resultsDiv.innerHTML = 'Searching...';
+    overlayResults.innerHTML = 'Searching...';
     const matches = await searchSite(q);
     if (matches.length === 0) {
-      resultsDiv.innerHTML = '<div>No results found.</div>';
+      overlayResults.innerHTML = '<div>No results found.</div>';
       return;
     }
     const ul = document.createElement('ul');
@@ -74,28 +134,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const a = document.createElement('a');
       a.href = `${page.url}#:~:text=${page.fragment}`;
       a.textContent = page.title;
-      const snippet = document.createElement('span');
-      snippet.innerHTML = ` - ${page.snippet}`;
+      const snippetDiv = document.createElement('div');
+      snippetDiv.innerHTML = page.snippet;
       li.appendChild(a);
-      li.appendChild(snippet);
+      li.appendChild(snippetDiv);
       ul.appendChild(li);
     }
-    resultsDiv.innerHTML = '';
-    resultsDiv.appendChild(ul);
+    overlayResults.innerHTML = '';
+    overlayResults.appendChild(ul);
   }
 
-  if (input) {
-    input.addEventListener('keydown', (e) => {
+  if (overlayInput) {
+    overlayInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         doSearch();
       }
     });
   }
-
-  document.addEventListener('click', (e) => {
-    const bar = document.getElementById('bottom-bar');
-    if (!bar.contains(e.target) && !resultsDiv.contains(e.target)) {
-      resultsDiv.style.display = 'none';
-    }
-  });
 });
+

--- a/otology/index.md
+++ b/otology/index.md
@@ -2,16 +2,34 @@
 layout: default
 title: Otology
 ---
-- 
+-
 [Clinic Guide](clinic-guide.html)
 
-- 
+-
+[Facial Nerve](facial-nerve.html)
+
+-
 [Neuro-otology Imaging](neuro-otology-imaging.html)
 
-- 
+-
 [Otitis](otitis.html)
 
-- 
+-
 [OR Guide](or-guide.html)
+
+-
+[Otosclerosis](otosclerosis.html)
+
+-
+[Temporal Bone Lab](temporal-bone-lab.html)
+
+-
+[The Cranial Nerves](the-cranial-nerves.html)
+
+-
+[Tinnitus](tinnitus.html)
+
+-
+[Vertigo](vertigo.html)
 
 


### PR DESCRIPTION
## Summary
- Add missing otology subpages to otology index and main index
- Rework search into full-screen overlay and render formatted snippets with partial-word matching

## Testing
- `python3 generate_pages_json.py`
- `node --check menu.js`
- `node --check search.js`


------
https://chatgpt.com/codex/tasks/task_e_688ea8eed3c4832fb1ef2d3cf4ae760e