### PR TITLE
Respect system light/dark mode

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <title>{{ page.title }}</title>
     <link
       rel="stylesheet"
@@ -14,6 +15,9 @@
         padding: 1rem;
         padding-bottom: 4rem;
         box-sizing: border-box;
+        color-scheme: light dark;
+        background: #fff;
+        color: #000;
       }
       #bottom-bar {
         position: fixed;
@@ -113,6 +117,22 @@
         }
         #bottom-bar input[type="search"] {
           padding: 0.75rem;
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #0d1117;
+          color: #c9d1d9;
+        }
+        #bottom-bar {
+          background: rgba(13, 17, 23, 0.9);
+          border-top: 1px solid #30363d;
+        }
+        #search-overlay {
+          background: #0d1117;
+        }
+        #search-overlay-header {
+          border-bottom: 1px solid #30363d;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- honor user's light or dark scheme preference by tagging the page and adding color-aware base styles
- adjust bottom bar and search overlay colors for dark theme via media queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eaef831b4832f8e00adda6ad07c85