### PR TITLE
Initialize collapsible headings after markdown render

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -179,6 +179,7 @@
         } catch (e) {
           content.textContent = md;
         }
+        window.dispatchEvent(new Event("markdown-rendered"));
       })();
     </script>
     <script src="{{ '/menu.js' | relative_url }}"></script>

--- a/site.js
+++ b/site.js
@@ -1,23 +1,9 @@
-document.addEventListener("DOMContentLoaded", () => {
-  const header = document.querySelector("header");
-  if (header) {
-    const threshold = 50;
-    const onScroll = () => {
-      if (window.scrollY > threshold) {
-        header.classList.add("collapsed");
-      } else {
-        header.classList.remove("collapsed");
-      }
-    };
-    window.addEventListener("scroll", onScroll);
-    onScroll();
-  }
-
-  // Make headings collapsible
+function initCollapsibleHeadings() {
   const main = document.querySelector("main, #content");
   if (main) {
     const headings = main.querySelectorAll("h1, h2, h3, h4, h5, h6");
     headings.forEach((heading) => {
+      if (heading.classList.contains("collapsible")) return;
       const level = parseInt(heading.tagName.substring(1));
       const section = [];
       let el = heading.nextElementSibling;
@@ -58,4 +44,24 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const header = document.querySelector("header");
+  if (header) {
+    const threshold = 50;
+    const onScroll = () => {
+      if (window.scrollY > threshold) {
+        header.classList.add("collapsed");
+      } else {
+        header.classList.remove("collapsed");
+      }
+    };
+    window.addEventListener("scroll", onScroll);
+    onScroll();
+  }
+
+  initCollapsibleHeadings();
 });
+
+window.addEventListener("markdown-rendered", initCollapsibleHeadings);


### PR DESCRIPTION
## Summary
- Extract collapsible heading logic into `initCollapsibleHeadings`
- Re-run collapsible heading setup after markdown rendering completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3572ac4832fb4d762e9160681f5