### PR TITLE
Cycle dark-mode h1 headings through rainbow colors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -134,6 +134,25 @@
         #search-overlay-header {
           border-bottom: 1px solid #30363d;
         }
+        /* Cycle through a rainbow for successive h1 headings */
+        h1:nth-of-type(6n + 1) {
+          color: #ff5555;
+        }
+        h1:nth-of-type(6n + 2) {
+          color: #ffb86c;
+        }
+        h1:nth-of-type(6n + 3) {
+          color: #f1fa8c;
+        }
+        h1:nth-of-type(6n + 4) {
+          color: #50fa7b;
+        }
+        h1:nth-of-type(6n + 5) {
+          color: #57c7ff;
+        }
+        h1:nth-of-type(6n + 6) {
+          color: #bd93f9;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- Cycle successive h1 headings through rainbow colors in dark mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688eb37d8da8832f874a7b87be15cef0