### PR TITLE
Render Markdown at build time via Jekyll

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -157,10 +157,9 @@
     </style>
   </head>
   <body>
-    <textarea id="markdown-src" style="display: none">
-{{ page.content | escape }}</textarea
-    >
-    <article id="content" class="markdown-body"></article>
+    <article id="content" class="markdown-body">
+{{ content }}
+    </article>
     <div id="bottom-bar">
       <button id="back-button" title="Back">&#8592;</button>
       <a id="home-button" title="Home" href="{{ '/' | relative_url }}"
@@ -179,28 +178,6 @@
       </div>
       <div id="search-overlay-results"></div>
     </div>
-    <script>
-      (async () => {
-        const src = document.getElementById("markdown-src");
-        const content = document.getElementById("content");
-        const md = src.value;
-        try {
-          const resp = await fetch("https://api.github.com/markdown", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "application/vnd.github+json",
-            },
-            body: JSON.stringify({ text: md }),
-          });
-          const html = await resp.text();
-          content.innerHTML = html;
-        } catch (e) {
-          content.textContent = md;
-        }
-        window.dispatchEvent(new Event("markdown-rendered"));
-      })();
-    </script>
     <script src="{{ '/menu.js' | relative_url }}"></script>
     <script src="{{ '/site.js' | relative_url }}"></script>
   </body>

--- a/site.js
+++ b/site.js
@@ -63,5 +63,3 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initCollapsibleHeadings();
 });
-
-window.addEventListener("markdown-rendered", initCollapsibleHeadings);


### PR DESCRIPTION
## Summary
- Render Markdown during the Jekyll build instead of calling GitHub's Markdown API at runtime.
- Remove unused `markdown-rendered` event logic.

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_688eb5fcf8f8832fb75a1fc9c97c7fdc