### PR TITLE
Add global header collapse toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -181,6 +181,7 @@
         >&#8962;</a
       >
       <input type="search" id="search-input" placeholder="Search..." />
+      <button id="collapse-toggle" title="Collapse all">&#8722;</button>
     </div>
     <div id="search-overlay">
       <div id="search-overlay-header">

--- a/site.js
+++ b/site.js
@@ -62,4 +62,32 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   initCollapsibleHeadings();
+
+  const collapseToggle = document.getElementById("collapse-toggle");
+  if (collapseToggle) {
+    let allCollapsed = false;
+    collapseToggle.addEventListener("click", () => {
+      const headings = document.querySelectorAll(
+        "h1.collapsible, h2.collapsible, h3.collapsible, h4.collapsible, h5.collapsible, h6.collapsible",
+      );
+      headings.forEach((heading) => {
+        const content = heading.nextElementSibling;
+        const icon = heading.querySelector(".collapse-icon");
+        if (!content || !content.classList.contains("collapsible-content"))
+          return;
+        if (!allCollapsed) {
+          content.style.display = "none";
+          heading.classList.add("collapsed");
+          if (icon) icon.textContent = "\u25B8";
+        } else {
+          content.style.display = "";
+          heading.classList.remove("collapsed");
+          if (icon) icon.textContent = "\u25BE";
+        }
+      });
+      allCollapsed = !allCollapsed;
+      collapseToggle.textContent = allCollapsed ? "+" : "\u2212";
+      collapseToggle.title = allCollapsed ? "Expand all" : "Collapse all";
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add toolbar button for collapsing/expanding all headers
- wire up button to toggle all collapsible sections

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec53409a4832f9ed917c2f1c2d4d6