### PR TITLE
Align dropdown caret size with header text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -109,7 +109,7 @@
       }
       .collapse-icon {
         margin-right: 0.25em;
-        font-size: 0.8em;
+        font-size: 1em;
       }
       @media (max-width: 600px) {
         body {


### PR DESCRIPTION
## Summary
- Increase `.collapse-icon` font size so dropdown carets match heading size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ec6443dd8832fb3262286ad9c6e36