### PR TITLE
Add glimmering sparkle effect to bold text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,6 +111,23 @@
         margin-right: 0.25em;
         font-size: 1em;
       }
+      .sparkle {
+        color: var(--sparkle-color);
+        animation: sparkle 1.5s ease-in-out infinite;
+      }
+      @keyframes sparkle {
+        0%,
+        100% {
+          text-shadow:
+            0 0 2px var(--sparkle-color),
+            0 0 4px var(--sparkle-color);
+        }
+        50% {
+          text-shadow:
+            0 0 8px var(--sparkle-color),
+            0 0 16px var(--sparkle-color);
+        }
+      }
       @media (max-width: 600px) {
         body {
           font-size: 18px;
@@ -143,38 +160,36 @@
         #search-overlay-header {
           border-bottom: 1px solid #30363d;
         }
-      /* Cycle through a rainbow for successive h1 and h2 headings */
-      h1:nth-of-type(6n + 1),
-      h2:nth-of-type(6n + 1) {
-        color: #57c7ff;
-      }
-      h1:nth-of-type(6n + 2),
-      h2:nth-of-type(6n + 2) {
-        color: #bd93f9;
-      }
-      h1:nth-of-type(6n + 3),
-      h2:nth-of-type(6n + 3) {
-        color: #ff5555;
-      }
-      h1:nth-of-type(6n + 4),
-      h2:nth-of-type(6n + 4) {
-        color: #ffb86c;
-      }
-      h1:nth-of-type(6n + 5),
-      h2:nth-of-type(6n + 5) {
-        color: #f1fa8c;
-      }
-      h1:nth-of-type(6n + 6),
-      h2:nth-of-type(6n + 6) {
-        color: #50fa7b;
-      }
+        /* Cycle through a rainbow for successive h1 and h2 headings */
+        h1:nth-of-type(6n + 1),
+        h2:nth-of-type(6n + 1) {
+          color: #57c7ff;
+        }
+        h1:nth-of-type(6n + 2),
+        h2:nth-of-type(6n + 2) {
+          color: #bd93f9;
+        }
+        h1:nth-of-type(6n + 3),
+        h2:nth-of-type(6n + 3) {
+          color: #ff5555;
+        }
+        h1:nth-of-type(6n + 4),
+        h2:nth-of-type(6n + 4) {
+          color: #ffb86c;
+        }
+        h1:nth-of-type(6n + 5),
+        h2:nth-of-type(6n + 5) {
+          color: #f1fa8c;
+        }
+        h1:nth-of-type(6n + 6),
+        h2:nth-of-type(6n + 6) {
+          color: #50fa7b;
+        }
       }
     </style>
   </head>
   <body>
-    <article id="content" class="markdown-body">
-{{ content }}
-    </article>
+    <article id="content" class="markdown-body">{{ content }}</article>
     <div id="bottom-bar">
       <button id="back-button" title="Back">&#8592;</button>
       <a id="home-button" title="Home" href="{{ '/' | relative_url }}"

--- a/site.js
+++ b/site.js
@@ -46,6 +46,25 @@ function initCollapsibleHeadings() {
   }
 }
 
+function applySparkleEffect() {
+  const headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
+  headings.forEach((heading) => {
+    const color = getComputedStyle(heading).color;
+    heading.querySelectorAll("strong, b").forEach((el) => {
+      el.classList.add("sparkle");
+      el.style.setProperty("--sparkle-color", color);
+    });
+    let el = heading.nextElementSibling;
+    while (el && !el.tagName.match(/^H[1-6]$/)) {
+      el.querySelectorAll("strong, b").forEach((bold) => {
+        bold.classList.add("sparkle");
+        bold.style.setProperty("--sparkle-color", color);
+      });
+      el = el.nextElementSibling;
+    }
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const header = document.querySelector("header");
   if (header) {
@@ -62,6 +81,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   initCollapsibleHeadings();
+  applySparkleEffect();
 
   const collapseToggle = document.getElementById("collapse-toggle");
   if (collapseToggle) {


### PR DESCRIPTION
## Summary
- Add `.sparkle` CSS class with animated text-shadow to create a glimmer matching heading colors.
- Implement `applySparkleEffect` in `site.js` to color and animate bold text based on its nearest heading.

## Testing
- `npx prettier -c site.js _layouts/default.html`


------
https://chatgpt.com/codex/tasks/task_e_688ec71a0e84832fb148ca1598b9cf7a