### PR TITLE
Use site logo as site icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" href="{{ '/media/site-logo.png' | relative_url }}" type="image/png" />
     <title>{{ page.title }}</title>
     <link
       rel="stylesheet"


### PR DESCRIPTION
## Summary
- Reference site logo as favicon in default layout

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_688ec8894774832fb88b6feb09d68b62