### PR TITLE
Rename site to Tufts Oto-HNS Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ENT Guidebook
+# Tufts Oto-HNS Guide
 
-This repository contains the source for the ENT Guidebook website. Pages are written in Markdown and built with [Jekyll](https://jekyllrb.com/). GitHub Pages will automatically generate the site when new changes are pushed.
+This repository contains the source for the Tufts Oto-HNS Guide website. Pages are written in Markdown and built with [Jekyll](https://jekyllrb.com/). GitHub Pages will automatically generate the site when new changes are pushed.
 
 To preview locally run:
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: ENT Guidebook
+title: Tufts Oto-HNS Guide
 markdown: kramdown
 kramdown:
   input: GFM


### PR DESCRIPTION
## Summary
- rename site title to "Tufts Oto-HNS Guide"
- update README to reflect new site name

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eca25fa00832fa91593bf940e4d96