### PR TITLE
Reduce sparkle intensity by half

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -120,13 +120,13 @@
         0%,
         100% {
           text-shadow:
-            0 0 2px var(--sparkle-color),
-            0 0 4px var(--sparkle-color);
+            0 0 1px var(--sparkle-color),
+            0 0 2px var(--sparkle-color);
         }
         50% {
           text-shadow:
-            0 0 8px var(--sparkle-color),
-            0 0 16px var(--sparkle-color);
+            0 0 4px var(--sparkle-color),
+            0 0 8px var(--sparkle-color);
         }
       }
       @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Decrease sparkle animation text-shadow values to reduce glimmer effect by 50%

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_688eca96adb8832f906b38a62a63de65