### PR TITLE
Add sparkle toggle button to index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -99,6 +99,7 @@
 
 [Map of Tufts Medical Center](resources/map-of-tufts-medical-center.html)
 
+<!-- markdownlint-disable-next-line MD025 -->
 # Editors and Contributors
 
 **Jonathan C. Simmonds, M.D.**
@@ -128,3 +129,6 @@ To edit this website - talk to me (Alex)
 To edit the pocket guide – go to the g-drive folder “ENT Pocket guide”
 
  ![Tufts Oto-HNS Pocket Guide](media/image1.png "right-50")
+
+<!-- markdownlint-disable-next-line MD033 -->
+<button id="sparkle-toggle">Enable sparkle</button>

--- a/site.js
+++ b/site.js
@@ -65,6 +65,13 @@ function applySparkleEffect() {
   });
 }
 
+function removeSparkleEffect() {
+  document.querySelectorAll(".sparkle").forEach((el) => {
+    el.classList.remove("sparkle");
+    el.style.removeProperty("--sparkle-color");
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const header = document.querySelector("header");
   if (header) {
@@ -81,7 +88,21 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   initCollapsibleHeadings();
-  applySparkleEffect();
+
+  let sparkleEnabled = false;
+  const sparkleToggle = document.getElementById("sparkle-toggle");
+  if (sparkleToggle) {
+    sparkleToggle.addEventListener("click", () => {
+      sparkleEnabled = !sparkleEnabled;
+      if (sparkleEnabled) {
+        applySparkleEffect();
+        sparkleToggle.textContent = "Disable sparkle";
+      } else {
+        removeSparkleEffect();
+        sparkleToggle.textContent = "Enable sparkle";
+      }
+    });
+  }
 
   const collapseToggle = document.getElementById("collapse-toggle");
   if (collapseToggle) {


### PR DESCRIPTION
## Summary
- Add sparkle toggle button at end of contributors section on home page, defaulting to off
- Implement sparkle enable/disable logic in site.js

## Testing
- `node --check site.js`
- `markdownlint index.md`


------
https://chatgpt.com/codex/tasks/task_e_688eccddbbdc832f9fb070692e7bf946