### PR TITLE
Fix contributor list layout and sparkle effect

### DIFF
--- a/index.md
+++ b/index.md
@@ -105,27 +105,16 @@
 
 <!-- markdownlint-disable MD033 -->
 <div id="contributors">
-  
-<b>Jonathan C. Simmonds, M.D. </b>
-
-<b>Jennifer L. Harb, M.D.</b>
-
-<b>Erin Haser, M.D.</b>
-
-<b>Ameer Shah, M.D.</b>
-
-<b>Samih Nassif, M.D.</b>
-
-<b>Andrew R. Scott, M.D.</b>
-
-<b>Michelle White, M.D.</b>
-
-<b>Anju Patel, M.D.</b>
-
-<b>Ramya Bharathi, M.D.</b>
-
-<b>Emily Gall, M.D.</b>
-
+<p><b>Jonathan C. Simmonds, M.D.</b></p>
+<p><b>Jennifer L. Harb, M.D.</b></p>
+<p><b>Erin Haser, M.D.</b></p>
+<p><b>Ameer Shah, M.D.</b></p>
+<p><b>Samih Nassif, M.D.</b></p>
+<p><b>Andrew R. Scott, M.D.</b></p>
+<p><b>Michelle White, M.D.</b></p>
+<p><b>Anju Patel, M.D.</b></p>
+<p><b>Ramya Bharathi, M.D.</b></p>
+<p><b>Emily Gall, M.D.</b></p>
 </div>
 
 <button id="sparkle-toggle">✨ Enable sparkle ✨</button>

--- a/site.js
+++ b/site.js
@@ -80,7 +80,6 @@ function applySparkleEffect() {
         bold.style.setProperty("--sparkle-color", color);
         if (bold.closest("#contributors")) {
           bold.style.color = color;
-          bold.classList.add("pazzaz");
         }
       });
       el = el.nextElementSibling;
@@ -92,12 +91,10 @@ function removeSparkleEffect() {
   document.querySelectorAll(".sparkle").forEach((el) => {
     el.classList.remove("sparkle");
     el.style.removeProperty("--sparkle-color");
-    if (el.classList.contains("pazzaz")) {
-      el.classList.remove("pazzaz");
-      if (el.closest("#contributors")) {
-        el.style.removeProperty("color");
-      }
+    if (el.closest("#contributors")) {
+      el.style.removeProperty("color");
     }
+    el.classList.remove("pazzaz");
   });
 }
 


### PR DESCRIPTION
## Summary
- Show each contributor on its own line on the homepage
- Limit sparkle effect to contributor text instead of their bounding boxes

## Testing
- `node --check site.js`


------
https://chatgpt.com/codex/tasks/task_e_688ed3f75390832fad00433b1241cedc