### PR TITLE
Fix contributor list layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -116,6 +116,17 @@
         margin-right: 0.25em;
         font-size: 1em;
       }
+      #contributors {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      #contributors p {
+        margin: 0;
+      }
+      #contributors p + p {
+        margin-top: 0.25rem;
+      }
       .sparkle {
         color: var(--sparkle-color);
         animation: sparkle 1.5s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- Ensure each contributor name is displayed on its own line by styling the contributors container as a vertical flex column.

## Testing
- `python -m py_compile clean_html.py convert_to_pure_markdown.py generate_pages_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688ed5203e88832f867beefea5a6a1e2