### PR TITLE
Align search field with menu bar color

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,11 +7,13 @@
     <link
       rel="icon"
       href="{{ '/media/site-logo.png' | relative_url }}"
-      type="image/png" />
+      type="image/png"
+    />
     <title>{{ page.title }}</title>
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css" />
+      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
+    />
     <style>
       body {
         margin: 0;
@@ -50,6 +52,11 @@
         flex: 1;
         padding: 0.5rem;
         font-size: 1em;
+        background: rgba(255, 255, 255, 0.9);
+        border-top: none;
+        border-left: none;
+        border-right: none;
+        border-bottom-width: 0.05em;
       }
       #search-overlay {
         position: fixed;
@@ -74,7 +81,7 @@
         padding: 0.5rem;
         font-size: 1em;
         border-top: none;
-        background-color: rgba(13, 17, 23, 0.9);
+        background: rgba(255, 255, 255, 0.9);
         border-left: none;
         border-right: none;
         border-bottom-width: 0.05em;
@@ -164,7 +171,6 @@
         box-shadow: 0 0 8px currentColor;
       }
       .pazzaz:hover {
-
         transform: scale(1.05) rotate(-2deg);
       }
       @keyframes groove {
@@ -192,11 +198,6 @@
         }
         #bottom-bar input[type="search"] {
           padding: 0.75rem;
-          border-top: none;
-          background-color: rgba(13, 17, 23, 0.9);
-          border-left: none;
-          border-right: none;
-          border-bottom-width: 0.05em;
         }
       }
       @media (prefers-color-scheme: dark) {
@@ -213,6 +214,10 @@
         }
         #search-overlay-header {
           border-bottom: 1px solid #30363d;
+        }
+        #bottom-bar input[type="search"],
+        #search-overlay-header input[type="search"] {
+          background: rgba(13, 17, 23, 0.9);
         }
         /* Cycle through a rainbow for successive h1 and h2 headings */
         h1:nth-of-type(6n + 1),
@@ -246,8 +251,9 @@
     <article id="content" class="markdown-body">{{ content }}</article>
     <div id="bottom-bar">
       <button id="back-button" title="Back">&#8592;</button>
-      <a id="home-button" title="Home"
-        href="{{ '/' | relative_url }}">&#8962;</a>
+      <a id="home-button" title="Home" href="{{ '/' | relative_url }}"
+        >&#8962;</a
+      >
       <input type="search" id="search-input" placeholder="Search..." />
       <button id="collapse-toggle" title="Collapse all">&#8722;</button>
     </div>
@@ -256,7 +262,8 @@
         <input
           type="search"
           id="search-overlay-input"
-          placeholder="Search..." />
+          placeholder="Search..."
+        />
         <button id="search-close" title="Close">&times;</button>
       </div>
       <div id="search-overlay-results"></div>


### PR DESCRIPTION
## Summary
- Match search inputs' background with menu bar in light and dark modes

## Testing
- `npm test`
- `python -m py_compile generate_pages_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688f943df8a0832fa5d8bad7eed7fced