### PR TITLE
Align search bar with site themes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,15 +48,15 @@
       #bottom-bar a {
         text-decoration: none;
       }
-      #bottom-bar input[type="search"] {
+      #bottom-bar input[type="search"],
+      #search-overlay-header input[type="search"] {
         flex: 1;
         padding: 0.5rem;
         font-size: 1em;
-        border-top: none;
-        background-color: rgba(13, 17, 23, 0.9);
-        border-left: none;
-        border-right: none;
-        border-bottom-width: 0.05em;
+        border: none;
+        border-bottom: 1px solid #ccc;
+        background: transparent;
+        color: inherit;
       }
       #search-overlay {
         position: fixed;
@@ -75,16 +75,6 @@
         padding: 0.5rem;
         border-bottom: 1px solid #ccc;
         gap: 0.5rem;
-      }
-      #search-overlay-header input[type="search"] {
-        flex: 1;
-        padding: 0.5rem;
-        font-size: 1em;
-        border-top: none;
-        background: rgba(255, 255, 255, 0.9);
-        border-left: none;
-        border-right: none;
-        border-bottom-width: 0.05em;
       }
       #search-overlay-results {
         flex: 1;
@@ -217,7 +207,9 @@
         }
         #bottom-bar input[type="search"],
         #search-overlay-header input[type="search"] {
-          background: rgba(13, 17, 23, 0.9);
+          background: transparent;
+          border-bottom: 1px solid #30363d;
+          color: inherit;
         }
         /* Cycle through a rainbow for successive h1 and h2 headings */
         h1:nth-of-type(6n + 1),


### PR DESCRIPTION
## Summary
- Make bottom bar and overlay search inputs transparent so backgrounds blend with light or dark themes
- Theme-aware search input borders: light mode uses #ccc, dark mode uses #30363d

## Testing
- `npx prettier --check _layouts/default.html`
- `npm test` *(fails: package.json missing)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f961315d0832fbf1f5ea7a5d3066b