### PR TITLE
Color h3 headings in rainbow

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -104,7 +104,8 @@
         text-decoration: none;
       }
       .markdown-body h1 a,
-      .markdown-body h2 a {
+      .markdown-body h2 a,
+      .markdown-body h3 a {
         color: inherit;
       }
       .collapsible {
@@ -211,29 +212,35 @@
           border-bottom: 1px solid #30363d;
           color: inherit;
         }
-        /* Cycle through a rainbow for successive h1 and h2 headings */
+        /* Cycle through a rainbow for successive h1, h2, and h3 headings */
         h1:nth-of-type(6n + 1),
-        h2:nth-of-type(6n + 1) {
+        h2:nth-of-type(6n + 1),
+        h3:nth-of-type(6n + 1) {
           color: #57c7ff;
         }
         h1:nth-of-type(6n + 2),
-        h2:nth-of-type(6n + 2) {
+        h2:nth-of-type(6n + 2),
+        h3:nth-of-type(6n + 2) {
           color: #bd93f9;
         }
         h1:nth-of-type(6n + 3),
-        h2:nth-of-type(6n + 3) {
+        h2:nth-of-type(6n + 3),
+        h3:nth-of-type(6n + 3) {
           color: #ff5555;
         }
         h1:nth-of-type(6n + 4),
-        h2:nth-of-type(6n + 4) {
+        h2:nth-of-type(6n + 4),
+        h3:nth-of-type(6n + 4) {
           color: #ffb86c;
         }
         h1:nth-of-type(6n + 5),
-        h2:nth-of-type(6n + 5) {
+        h2:nth-of-type(6n + 5),
+        h3:nth-of-type(6n + 5) {
           color: #f1fa8c;
         }
         h1:nth-of-type(6n + 6),
-        h2:nth-of-type(6n + 6) {
+        h2:nth-of-type(6n + 6),
+        h3:nth-of-type(6n + 6) {
           color: #50fa7b;
         }
       }


### PR DESCRIPTION
## Summary
- include h3 headings in anchor link inheritance
- cycle rainbow colors over h3 headings like h1 and h2

## Testing
- `npx prettier -w _layouts/default.html`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_688fbd5e03dc832fab61412a94258336