### PR TITLE
Extend rainbow headings to light mode with tiered contrast

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -174,6 +174,61 @@
           box-shadow: 0 0 16px currentColor;
         }
       }
+      /* Cycle through a rainbow for successive h1, h2, and h3 headings */
+      h1:nth-of-type(6n + 1) {
+        color: #0088cd;
+      }
+      h2:nth-of-type(6n + 1) {
+        color: #01aaff;
+      }
+      h3:nth-of-type(6n + 1) {
+        color: #34bbfe;
+      }
+      h1:nth-of-type(6n + 2) {
+        color: #640ce1;
+      }
+      h2:nth-of-type(6n + 2) {
+        color: #8335f3;
+      }
+      h3:nth-of-type(6n + 2) {
+        color: #a66df6;
+      }
+      h1:nth-of-type(6n + 3) {
+        color: #cb0000;
+      }
+      h2:nth-of-type(6n + 3) {
+        color: #ff0000;
+      }
+      h3:nth-of-type(6n + 3) {
+        color: #ff3232;
+      }
+      h1:nth-of-type(6n + 4) {
+        color: #d97000;
+      }
+      h2:nth-of-type(6n + 4) {
+        color: #fe8c11;
+      }
+      h3:nth-of-type(6n + 4) {
+        color: #ffa647;
+      }
+      h1:nth-of-type(6n + 5) {
+        color: #cee009;
+      }
+      h2:nth-of-type(6n + 5) {
+        color: #e5f52e;
+      }
+      h3:nth-of-type(6n + 5) {
+        color: #ecf866;
+      }
+      h1:nth-of-type(6n + 6) {
+        color: #05c034;
+      }
+      h2:nth-of-type(6n + 6) {
+        color: #06f041;
+      }
+      h3:nth-of-type(6n + 6) {
+        color: #2ff962;
+      }
       @media (max-width: 600px) {
         body {
           font-size: 18px;
@@ -213,35 +268,59 @@
           color: inherit;
         }
         /* Cycle through a rainbow for successive h1, h2, and h3 headings */
-        h1:nth-of-type(6n + 1),
-        h2:nth-of-type(6n + 1),
-        h3:nth-of-type(6n + 1) {
+        h1:nth-of-type(6n + 1) {
           color: #57c7ff;
         }
-        h1:nth-of-type(6n + 2),
-        h2:nth-of-type(6n + 2),
-        h3:nth-of-type(6n + 2) {
+        h2:nth-of-type(6n + 1) {
+          color: #12b0ff;
+        }
+        h3:nth-of-type(6n + 1) {
+          color: #0088cd;
+        }
+        h1:nth-of-type(6n + 2) {
           color: #bd93f9;
         }
-        h1:nth-of-type(6n + 3),
-        h2:nth-of-type(6n + 3),
-        h3:nth-of-type(6n + 3) {
+        h2:nth-of-type(6n + 2) {
+          color: #8f47f4;
+        }
+        h3:nth-of-type(6n + 2) {
+          color: #640ce1;
+        }
+        h1:nth-of-type(6n + 3) {
           color: #ff5555;
         }
-        h1:nth-of-type(6n + 4),
-        h2:nth-of-type(6n + 4),
-        h3:nth-of-type(6n + 4) {
+        h2:nth-of-type(6n + 3) {
+          color: #fe1111;
+        }
+        h3:nth-of-type(6n + 3) {
+          color: #cb0000;
+        }
+        h1:nth-of-type(6n + 4) {
           color: #ffb86c;
         }
-        h1:nth-of-type(6n + 5),
-        h2:nth-of-type(6n + 5),
-        h3:nth-of-type(6n + 5) {
+        h2:nth-of-type(6n + 4) {
+          color: #fe9423;
+        }
+        h3:nth-of-type(6n + 4) {
+          color: #d97000;
+        }
+        h1:nth-of-type(6n + 5) {
           color: #f1fa8c;
         }
-        h1:nth-of-type(6n + 6),
-        h2:nth-of-type(6n + 6),
-        h3:nth-of-type(6n + 6) {
+        h2:nth-of-type(6n + 5) {
+          color: #e7f641;
+        }
+        h3:nth-of-type(6n + 5) {
+          color: #cee009;
+        }
+        h1:nth-of-type(6n + 6) {
           color: #50fa7b;
+        }
+        h2:nth-of-type(6n + 6) {
+          color: #0ff84a;
+        }
+        h3:nth-of-type(6n + 6) {
+          color: #05c034;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- apply rainbow colors to headings in light mode using darker hues
- ensure h1 > h2 > h3 contrast in both light and dark themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0323ef4832fa7063a4665fb8bd4