### PR TITLE
feat: apply GT Standard typography

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="https://fonts.cdnfonts.com/css/gt-standard"
+    />
     <style>
       body {
         margin: 0;
@@ -23,6 +27,21 @@
         color-scheme: light dark;
         background: #fff;
         color: #000;
+        font-family: "GT Standard", sans-serif;
+        font-weight: 300;
+        font-optical-sizing: auto;
+      }
+      h1 {
+        font-weight: 700;
+        font-variation-settings: "opsz" 40;
+      }
+      h2 {
+        font-weight: 600;
+        font-variation-settings: "opsz" 32;
+      }
+      h3 {
+        font-weight: 500;
+        font-variation-settings: "opsz" 24;
       }
       #bottom-bar {
         position: fixed;
@@ -35,7 +54,7 @@
         padding: 0.75rem 1rem;
         background: rgba(255, 255, 255, 0.9);
         border-top: 1px solid #ccc;
-        font-family: sans-serif;
+        font-family: "GT Standard", sans-serif;
         font-size: 1.2rem;
       }
       #bottom-bar button,
@@ -80,7 +99,7 @@
         flex: 1;
         overflow-y: auto;
         padding: 0.5rem 1rem;
-        font-family: sans-serif;
+        font-family: "GT Standard", sans-serif;
       }
       #search-overlay-results ul {
         list-style: none;


### PR DESCRIPTION
## Summary
- load GT Standard font across the site
- set airy body copy and heavier headings using variable font settings

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_688fc1c5d28c832fa8921c35c9d9af81