### PR TITLE
Desaturate h3 headings from their h2 color

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -174,15 +174,12 @@
           box-shadow: 0 0 16px currentColor;
         }
       }
-      /* Cycle through a rainbow for successive h1, h2, and h3 headings */
+      /* Cycle through a rainbow for successive h1 and h2 headings */
       h1:nth-of-type(6n + 1) {
         color: #0088cd;
       }
       h2:nth-of-type(6n + 1) {
         color: #01aaff;
-      }
-      h3:nth-of-type(6n + 1) {
-        color: #34bbfe;
       }
       h1:nth-of-type(6n + 2) {
         color: #640ce1;
@@ -190,17 +187,11 @@
       h2:nth-of-type(6n + 2) {
         color: #8335f3;
       }
-      h3:nth-of-type(6n + 2) {
-        color: #a66df6;
-      }
       h1:nth-of-type(6n + 3) {
         color: #cb0000;
       }
       h2:nth-of-type(6n + 3) {
         color: #ff0000;
-      }
-      h3:nth-of-type(6n + 3) {
-        color: #ff3232;
       }
       h1:nth-of-type(6n + 4) {
         color: #d97000;
@@ -208,26 +199,17 @@
       h2:nth-of-type(6n + 4) {
         color: #fe8c11;
       }
-      h3:nth-of-type(6n + 4) {
-        color: #ffa647;
-      }
       h1:nth-of-type(6n + 5) {
         color: #cee009;
       }
       h2:nth-of-type(6n + 5) {
         color: #e5f52e;
       }
-      h3:nth-of-type(6n + 5) {
-        color: #ecf866;
-      }
       h1:nth-of-type(6n + 6) {
         color: #05c034;
       }
       h2:nth-of-type(6n + 6) {
         color: #06f041;
-      }
-      h3:nth-of-type(6n + 6) {
-        color: #2ff962;
       }
       @media (max-width: 600px) {
         body {
@@ -267,15 +249,12 @@
           border-bottom: 1px solid #30363d;
           color: inherit;
         }
-        /* Cycle through a rainbow for successive h1, h2, and h3 headings */
+        /* Cycle through a rainbow for successive h1 and h2 headings */
         h1:nth-of-type(6n + 1) {
           color: #57c7ff;
         }
         h2:nth-of-type(6n + 1) {
           color: #12b0ff;
-        }
-        h3:nth-of-type(6n + 1) {
-          color: #0088cd;
         }
         h1:nth-of-type(6n + 2) {
           color: #bd93f9;
@@ -283,17 +262,11 @@
         h2:nth-of-type(6n + 2) {
           color: #8f47f4;
         }
-        h3:nth-of-type(6n + 2) {
-          color: #640ce1;
-        }
         h1:nth-of-type(6n + 3) {
           color: #ff5555;
         }
         h2:nth-of-type(6n + 3) {
           color: #fe1111;
-        }
-        h3:nth-of-type(6n + 3) {
-          color: #cb0000;
         }
         h1:nth-of-type(6n + 4) {
           color: #ffb86c;
@@ -301,26 +274,17 @@
         h2:nth-of-type(6n + 4) {
           color: #fe9423;
         }
-        h3:nth-of-type(6n + 4) {
-          color: #d97000;
-        }
         h1:nth-of-type(6n + 5) {
           color: #f1fa8c;
         }
         h2:nth-of-type(6n + 5) {
           color: #e7f641;
         }
-        h3:nth-of-type(6n + 5) {
-          color: #cee009;
-        }
         h1:nth-of-type(6n + 6) {
           color: #50fa7b;
         }
         h2:nth-of-type(6n + 6) {
           color: #0ff84a;
-        }
-        h3:nth-of-type(6n + 6) {
-          color: #05c034;
         }
       }
     </style>

--- a/site.js
+++ b/site.js
@@ -46,6 +46,55 @@ function initCollapsibleHeadings() {
   }
 }
 
+function adjustH3HeadingColors() {
+  document.querySelectorAll("h2").forEach((h2) => {
+    const baseColor = getComputedStyle(h2).color;
+    const { h, s, l } = rgbToHsl(baseColor);
+    let el = h2.nextElementSibling;
+    let index = 0;
+    while (el && !el.tagName.match(/^H[12]$/)) {
+      if (el.tagName === "H3") {
+        const saturation = Math.max(0, s - index * 10);
+        el.style.color = `hsl(${h}, ${saturation}%, ${l}%)`;
+        index++;
+      }
+      el = el.nextElementSibling;
+    }
+  });
+}
+
+function rgbToHsl(rgb) {
+  const m = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!m) return { h: 0, s: 0, l: 0 };
+  let r = m[1] / 255,
+    g = m[2] / 255,
+    b = m[3] / 255;
+  const max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  let h,
+    s,
+    l = (max + min) / 2;
+  if (max === min) {
+    h = s = 0;
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return { h, s: s * 100, l: l * 100 };
+}
+
 function syncBoldTextColors() {
   const headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
   headings.forEach((heading) => {
@@ -115,6 +164,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initCollapsibleHeadings();
 
+  adjustH3HeadingColors();
   syncBoldTextColors();
 
   let sparkleEnabled = false;


### PR DESCRIPTION
## Summary
- Remove rainbow color cycling for `h3` tags and only cycle colors for `h1` and `h2`.
- Add script to color each `h3` based on the preceding `h2` with gradually reduced saturation.

## Testing
- `npx prettier -w site.js _layouts/default.html`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc25cadf0832f8b7b1f5311fcc6b3