### PR TITLE
Fix h3 heading color inheritance

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://fonts.cdnfonts.com/css/gt-standard"
-    />
+    <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/gt-standard" />
     <style>
       body {
         margin: 0;
@@ -31,7 +28,9 @@
           radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
           radial-gradient(rgba(0, 0, 0, 0.02) 1px, transparent 1px);
         background-size: 6px 6px;
-        background-position: 0 0, 3px 3px;
+        background-position:
+          0 0,
+          3px 3px;
         font-family: "GT Standard", sans-serif;
         font-weight: 300;
         font-optical-sizing: auto;
@@ -126,6 +125,9 @@
         background-color: transparent;
         color: #57c7ff;
         text-decoration: none;
+      }
+      .markdown-body h3 {
+        color: inherit;
       }
       .markdown-body h1 a,
       .markdown-body h2 a,


### PR DESCRIPTION
## Summary
- ensure `.markdown-body h3` elements inherit their parent color

## Testing
- `npx prettier _layouts/default.html --check`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc421b514832fb3c3811cea855294