### PR TITLE
Expose dot‑matrix background behind text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,6 +35,9 @@
         font-weight: 300;
         font-optical-sizing: auto;
       }
+      .markdown-body {
+        background: transparent;
+      }
       h1 {
         font-weight: 700;
         font-variation-settings: "opsz" 40;


### PR DESCRIPTION
## Summary
- remove default white background from markdown content so dotted site background shows through

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc563e380832f96895e29195a5864