### PR TITLE
Enable color cycling for h3 headings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -129,9 +129,6 @@
         color: #57c7ff;
         text-decoration: none;
       }
-      .markdown-body h3 {
-        color: inherit;
-      }
       .markdown-body h1 a,
       .markdown-body h2 a,
       .markdown-body h3 a {
@@ -203,41 +200,47 @@
           box-shadow: 0 0 16px currentColor;
         }
       }
-      /* Cycle through a rainbow for successive h1 and h2 headings */
+      /* Cycle through a rainbow for successive h1, h2, and h3 headings */
       h1:nth-of-type(6n + 1) {
         color: #0088cd;
       }
-      h2:nth-of-type(6n + 1) {
+      h2:nth-of-type(6n + 1),
+      h3:nth-of-type(6n + 1) {
         color: #01aaff;
       }
       h1:nth-of-type(6n + 2) {
         color: #640ce1;
       }
-      h2:nth-of-type(6n + 2) {
+      h2:nth-of-type(6n + 2),
+      h3:nth-of-type(6n + 2) {
         color: #8335f3;
       }
       h1:nth-of-type(6n + 3) {
         color: #cb0000;
       }
-      h2:nth-of-type(6n + 3) {
+      h2:nth-of-type(6n + 3),
+      h3:nth-of-type(6n + 3) {
         color: #ff0000;
       }
       h1:nth-of-type(6n + 4) {
         color: #d97000;
       }
-      h2:nth-of-type(6n + 4) {
+      h2:nth-of-type(6n + 4),
+      h3:nth-of-type(6n + 4) {
         color: #fe8c11;
       }
       h1:nth-of-type(6n + 5) {
         color: #cee009;
       }
-      h2:nth-of-type(6n + 5) {
+      h2:nth-of-type(6n + 5),
+      h3:nth-of-type(6n + 5) {
         color: #e5f52e;
       }
       h1:nth-of-type(6n + 6) {
         color: #05c034;
       }
-      h2:nth-of-type(6n + 6) {
+      h2:nth-of-type(6n + 6),
+      h3:nth-of-type(6n + 6) {
         color: #06f041;
       }
       @media (max-width: 600px) {
@@ -281,41 +284,47 @@
           border-bottom: 1px solid #30363d;
           color: inherit;
         }
-        /* Cycle through a rainbow for successive h1 and h2 headings */
+        /* Cycle through a rainbow for successive h1, h2, and h3 headings */
         h1:nth-of-type(6n + 1) {
           color: #57c7ff;
         }
-        h2:nth-of-type(6n + 1) {
+        h2:nth-of-type(6n + 1),
+        h3:nth-of-type(6n + 1) {
           color: #12b0ff;
         }
         h1:nth-of-type(6n + 2) {
           color: #bd93f9;
         }
-        h2:nth-of-type(6n + 2) {
+        h2:nth-of-type(6n + 2),
+        h3:nth-of-type(6n + 2) {
           color: #8f47f4;
         }
         h1:nth-of-type(6n + 3) {
           color: #ff5555;
         }
-        h2:nth-of-type(6n + 3) {
+        h2:nth-of-type(6n + 3),
+        h3:nth-of-type(6n + 3) {
           color: #fe1111;
         }
         h1:nth-of-type(6n + 4) {
           color: #ffb86c;
         }
-        h2:nth-of-type(6n + 4) {
+        h2:nth-of-type(6n + 4),
+        h3:nth-of-type(6n + 4) {
           color: #fe9423;
         }
         h1:nth-of-type(6n + 5) {
           color: #f1fa8c;
         }
-        h2:nth-of-type(6n + 5) {
+        h2:nth-of-type(6n + 5),
+        h3:nth-of-type(6n + 5) {
           color: #e7f641;
         }
         h1:nth-of-type(6n + 6) {
           color: #50fa7b;
         }
-        h2:nth-of-type(6n + 6) {
+        h2:nth-of-type(6n + 6),
+        h3:nth-of-type(6n + 6) {
           color: #0ff84a;
         }
       }


### PR DESCRIPTION
## Summary
- include h3 elements in the rainbow color cycle for both light and dark themes
- allow h3 colors to show by removing an overriding style

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688fc787ad5c832f97c71f5d85da1745