### PR TITLE
Align h3 heading colors with parent heading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -200,47 +200,41 @@
           box-shadow: 0 0 16px currentColor;
         }
       }
-      /* Cycle through a rainbow for successive h1, h2, and h3 headings */
+      /* Cycle through a rainbow for successive h1 and h2 headings */
       h1:nth-of-type(6n + 1) {
         color: #0088cd;
       }
-      h2:nth-of-type(6n + 1),
-      h3:nth-of-type(6n + 1) {
+      h2:nth-of-type(6n + 1) {
         color: #01aaff;
       }
       h1:nth-of-type(6n + 2) {
         color: #640ce1;
       }
-      h2:nth-of-type(6n + 2),
-      h3:nth-of-type(6n + 2) {
+      h2:nth-of-type(6n + 2) {
         color: #8335f3;
       }
       h1:nth-of-type(6n + 3) {
         color: #cb0000;
       }
-      h2:nth-of-type(6n + 3),
-      h3:nth-of-type(6n + 3) {
+      h2:nth-of-type(6n + 3) {
         color: #ff0000;
       }
       h1:nth-of-type(6n + 4) {
         color: #d97000;
       }
-      h2:nth-of-type(6n + 4),
-      h3:nth-of-type(6n + 4) {
+      h2:nth-of-type(6n + 4) {
         color: #fe8c11;
       }
       h1:nth-of-type(6n + 5) {
         color: #cee009;
       }
-      h2:nth-of-type(6n + 5),
-      h3:nth-of-type(6n + 5) {
+      h2:nth-of-type(6n + 5) {
         color: #e5f52e;
       }
       h1:nth-of-type(6n + 6) {
         color: #05c034;
       }
-      h2:nth-of-type(6n + 6),
-      h3:nth-of-type(6n + 6) {
+      h2:nth-of-type(6n + 6) {
         color: #06f041;
       }
       @media (max-width: 600px) {
@@ -284,47 +278,41 @@
           border-bottom: 1px solid #30363d;
           color: inherit;
         }
-        /* Cycle through a rainbow for successive h1, h2, and h3 headings */
+        /* Cycle through a rainbow for successive h1 and h2 headings */
         h1:nth-of-type(6n + 1) {
           color: #57c7ff;
         }
-        h2:nth-of-type(6n + 1),
-        h3:nth-of-type(6n + 1) {
+        h2:nth-of-type(6n + 1) {
           color: #12b0ff;
         }
         h1:nth-of-type(6n + 2) {
           color: #bd93f9;
         }
-        h2:nth-of-type(6n + 2),
-        h3:nth-of-type(6n + 2) {
+        h2:nth-of-type(6n + 2) {
           color: #8f47f4;
         }
         h1:nth-of-type(6n + 3) {
           color: #ff5555;
         }
-        h2:nth-of-type(6n + 3),
-        h3:nth-of-type(6n + 3) {
+        h2:nth-of-type(6n + 3) {
           color: #fe1111;
         }
         h1:nth-of-type(6n + 4) {
           color: #ffb86c;
         }
-        h2:nth-of-type(6n + 4),
-        h3:nth-of-type(6n + 4) {
+        h2:nth-of-type(6n + 4) {
           color: #fe9423;
         }
         h1:nth-of-type(6n + 5) {
           color: #f1fa8c;
         }
-        h2:nth-of-type(6n + 5),
-        h3:nth-of-type(6n + 5) {
+        h2:nth-of-type(6n + 5) {
           color: #e7f641;
         }
         h1:nth-of-type(6n + 6) {
           color: #50fa7b;
         }
-        h2:nth-of-type(6n + 6),
-        h3:nth-of-type(6n + 6) {
+        h2:nth-of-type(6n + 6) {
           color: #0ff84a;
         }
       }

--- a/site.js
+++ b/site.js
@@ -47,52 +47,16 @@ function initCollapsibleHeadings() {
 }
 
 function adjustH3HeadingColors() {
-  document.querySelectorAll("h2").forEach((h2) => {
-    const baseColor = getComputedStyle(h2).color;
-    const { h, s, l } = rgbToHsl(baseColor);
-    let el = h2.nextElementSibling;
-    let index = 0;
-    while (el && !el.tagName.match(/^H[12]$/)) {
-      if (el.tagName === "H3") {
-        const saturation = Math.max(0, s - index * 10);
-        el.style.color = `hsl(${h}, ${saturation}%, ${l}%)`;
-        index++;
-      }
-      el = el.nextElementSibling;
+  document.querySelectorAll("h3").forEach((h3) => {
+    let prev = h3.previousElementSibling;
+    while (prev && !prev.tagName.match(/^H[12]$/)) {
+      prev = prev.previousElementSibling;
+    }
+    if (prev) {
+      const color = getComputedStyle(prev).color;
+      h3.style.color = color;
     }
   });
-}
-
-function rgbToHsl(rgb) {
-  const m = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-  if (!m) return { h: 0, s: 0, l: 0 };
-  let r = m[1] / 255,
-    g = m[2] / 255,
-    b = m[3] / 255;
-  const max = Math.max(r, g, b),
-    min = Math.min(r, g, b);
-  let h,
-    s,
-    l = (max + min) / 2;
-  if (max === min) {
-    h = s = 0;
-  } else {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r:
-        h = (g - b) / d + (g < b ? 6 : 0);
-        break;
-      case g:
-        h = (b - r) / d + 2;
-        break;
-      case b:
-        h = (r - g) / d + 4;
-        break;
-    }
-    h *= 60;
-  }
-  return { h, s: s * 100, l: l * 100 };
 }
 
 function syncBoldTextColors() {


### PR DESCRIPTION
## Summary
- Remove rainbow cycling from h3 headings in both light and dark modes.
- Let h3 headings inherit the color of the nearest higher-level heading via JavaScript.

## Testing
- `npm test` *(fails: could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fca567aec832faf0e00305422b4e3