### PR TITLE
Increase background dot spacing

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,10 +27,10 @@
         background-image:
           radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
           radial-gradient(rgba(0, 0, 0, 0.02) 1px, transparent 1px);
-        background-size: 6px 6px;
+        background-size: 18px 18px;
         background-position:
           0 0,
-          3px 3px;
+          9px 9px;
         font-family: "GT Standard", sans-serif;
         font-weight: 300;
         font-optical-sizing: auto;


### PR DESCRIPTION
## Summary
- Triple spacing of dotted background pattern in default layout for a lighter, less dense appearance.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688fcab62e20832fbf17c5ebf0e1769b