### PR TITLE
fix: ensure h3 headings inherit previous color

### DIFF
--- a/site.js
+++ b/site.js
@@ -47,14 +47,12 @@ function initCollapsibleHeadings() {
 }
 
 function adjustH3HeadingColors() {
-  document.querySelectorAll("h3").forEach((h3) => {
-    let prev = h3.previousElementSibling;
-    while (prev && !prev.tagName.match(/^H[12]$/)) {
-      prev = prev.previousElementSibling;
-    }
-    if (prev) {
-      const color = getComputedStyle(prev).color;
-      h3.style.color = color;
+  let color = "";
+  document.querySelectorAll("h1, h2, h3").forEach((el) => {
+    if (el.tagName.match(/^H[12]$/)) {
+      color = getComputedStyle(el).color;
+    } else if (el.tagName === "H3" && color) {
+      el.style.color = color;
     }
   });
 }


### PR DESCRIPTION
## Summary
- ensure every `h3` inherits the color of the preceding `h1` or `h2`

## Testing
- `npx prettier -w site.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fcbe3443c832fbfb8be9a6652107f