### PR TITLE
Improve yellow and green contrast in light mode

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,14 @@
     />
     <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/gt-standard" />
     <style>
+      @media (prefers-color-scheme: light) {
+        :root {
+          --fgColor-success: #00782a;
+          --fgColor-attention: #8a6100;
+          --bgColor-attention-muted: #ffe680;
+          --color-prettylights-syntax-markup-inserted-bg: #b8f5ba;
+        }
+      }
       body {
         margin: 0;
         padding: 1rem;
@@ -226,16 +234,16 @@
         color: #fe8c11;
       }
       h1:nth-of-type(6n + 5) {
-        color: #cee009;
+        color: #b59a00;
       }
       h2:nth-of-type(6n + 5) {
-        color: #e5f52e;
+        color: #d4b000;
       }
       h1:nth-of-type(6n + 6) {
-        color: #05c034;
+        color: #00782a;
       }
       h2:nth-of-type(6n + 6) {
-        color: #06f041;
+        color: #00a838;
       }
       @media (max-width: 600px) {
         body {


### PR DESCRIPTION
## Summary
- darken light-mode yellow/green heading colors for better readability
- tweak light-mode success/attention CSS variables to improve contrast

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688fce795310832fbf9c8354a08d4e29