### PR TITLE
Move quick links below main title

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,5 @@
+# Tufts Oto-HNS Guide
+
 <style>
 .quick-links {
   display: flex;
@@ -88,8 +90,6 @@
     <span>OpenEvidence</span>
   </a>
 </div>
-
-# Tufts Oto-HNS Guide
 
 ## [Orientation](orientation/index.html)
 


### PR DESCRIPTION
## Summary
- move the quick link button group on the home page to display immediately after the main title

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5b5e13bdc832fb56a1397712c64e6