### PR TITLE
Fix laterality checkbox mapping in consent filler

### DIFF
--- a/blank-consent.md
+++ b/blank-consent.md
@@ -505,10 +505,10 @@ Use this page to fill a surgical consent and download a completed copy. Select f
     { id: 'additional-risks', name: 'Additional Risks' }
   ];
 
-  const checkboxFields = {
-    Left: 'Left',
-    Right: 'Right',
-    Bilateral: 'Bilateral'
+  const checkboxFieldCandidates = {
+    Left: ['Left', 'Laterality Left', 'Side Left'],
+    Right: ['Right', 'Laterality Right', 'Side Right'],
+    Bilateral: ['Bilateral', 'Laterality Bilateral', 'Side Bilateral']
   };
 
   function setStatus(message, isError = false) {
@@ -603,6 +603,10 @@ Use this page to fill a surgical consent and download a completed copy. Select f
     if (radio) {
       radio.checked = true;
     }
+  }
+
+  function resolveFormFieldName(formFieldNames, candidates) {
+    return candidates.find((candidate) => formFieldNames.has(candidate)) || null;
   }
 
   function applyTemplate(template) {
@@ -761,16 +765,21 @@ Use this page to fill a surgical consent and download a completed copy. Select f
       }
     }
 
-    Object.values(checkboxFields).forEach((fieldName) => {
-      if (!formFieldNames.has(fieldName)) return;
+    const resolvedCheckboxFields = Object.fromEntries(
+      Object.entries(checkboxFieldCandidates)
+        .map(([side, candidates]) => [side, resolveFormFieldName(formFieldNames, candidates)])
+        .filter(([, fieldName]) => Boolean(fieldName)),
+    );
+
+    Object.values(resolvedCheckboxFields).forEach((fieldName) => {
       const checkbox = form.getCheckBox(fieldName);
       checkbox.uncheck();
     });
 
     const selectedSide = formEl.querySelector('input[name="side"]:checked');
     if (selectedSide) {
-      const fieldName = checkboxFields[selectedSide.value];
-      if (formFieldNames.has(fieldName)) {
+      const fieldName = resolvedCheckboxFields[selectedSide.value];
+      if (fieldName) {
         const checkbox = form.getCheckBox(fieldName);
         checkbox.check();
       }


### PR DESCRIPTION
### Motivation
- The laterality selection in the consent PDF filler failed when the target PDF used slightly different checkbox field names, so laterality choices were not being applied to the output PDF.

### Description
- Replace the single hardcoded checkbox map with `checkboxFieldCandidates` that contains plausible field-name variants for `Left`, `Right`, and `Bilateral`.
- Add `resolveFormFieldName(formFieldNames, candidates)` to pick the actual field name present in the loaded PDF from a candidate list.
- Build `resolvedCheckboxFields` from `checkboxFieldCandidates` and use those resolved names to `uncheck()` and `check()` PDF checkboxes instead of assuming exact names.
- Preserve existing radio input handling and template application logic while making PDF checkbox mapping robust to naming differences.

### Testing
- Ran `python -m py_compile consent_pdf_to_json.py` and it completed successfully.
- Installed `pypdf` and used it to inspect `blank-consent.pdf` form fields to verify the candidate names and confirm the updated mapping logic covers the observed field names; the inspection commands executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d901051424832f809b4aace8d70787)