### PR TITLE
Improve Acrobat compatibility for filled consent PDFs

### DIFF
--- a/blank-consent.md
+++ b/blank-consent.md
@@ -791,6 +791,15 @@ Use this page to fill a surgical consent and download a completed copy. Select f
       console.warn('Unable to update PDF field appearances.', error);
     }
 
+    try {
+      const acroForm = pdfDoc.catalog.lookup(PDFLib.PDFName.of('AcroForm'));
+      if (acroForm && typeof acroForm.set === 'function') {
+        acroForm.set(PDFLib.PDFName.of('NeedAppearances'), PDFLib.PDFBool.True);
+      }
+    } catch (error) {
+      console.warn('Unable to set AcroForm NeedAppearances flag.', error);
+    }
+
     let updateFieldAppearances = true;
     try {
       form.flatten();
@@ -799,7 +808,10 @@ Use this page to fill a surgical consent and download a completed copy. Select f
       console.warn('Unable to flatten the PDF form fields.', error);
     }
 
-    return await pdfDoc.save({ updateFieldAppearances });
+    return await pdfDoc.save({
+      updateFieldAppearances,
+      useObjectStreams: false
+    });
   }
 
   formEl.addEventListener('submit', async (event) => {


### PR DESCRIPTION
### Motivation
- Acrobat was not reliably rendering filled form values produced by the in-browser PDF generator, so the PDF output needs small compatibility tweaks to ensure field contents appear in Acrobat.
- Some PDF readers are stricter about object streams and appearance flags, so broadening compatibility reduces viewer-specific rendering differences.
- Preserve existing appearance-update and flatten behavior while adding fallback measures to improve rendering in strict readers.

### Description
- In `blank-consent.md`'s `buildPdf` flow the AcroForm `NeedAppearances` flag is set on the document catalog to encourage viewers like Acrobat to regenerate field appearances (`NeedAppearances`).
- The call to `pdfDoc.save(...)` was updated to disable object streams by passing `useObjectStreams: false` to improve compatibility with older/stricter PDF readers.
- Existing calls to `form.updateFieldAppearances(font)` and `form.flatten()` are preserved and remain guarded by try/catch blocks to retain current error handling.

### Testing
- No automated tests were run for this browser-side inline script change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9028459c4832fae9b8581d80f1e49)