### PR TITLE
Add comprehensive OR orientation guide for residents

### DIFF
--- a/index.md
+++ b/index.md
@@ -135,6 +135,8 @@
 
 [Vacation Requests](orientation/vacation-requests.html)
 
+[OR Orientation](orientation/or-orientation.html)
+
 ## [Calls and Consults](on-call/index.html)
 
 [On-Call](on-call/index.html)

--- a/orientation/index.md
+++ b/orientation/index.md
@@ -33,3 +33,6 @@
 [Vacation Requests](vacation-requests.html)
 
 
+[OR Orientation](or-orientation.html)
+
+

--- a/orientation/or-orientation.md
+++ b/orientation/or-orientation.md
@@ -1,0 +1,100 @@
+# OR Orientation
+
+## Pre-Op & Consent Process
+
+- **Three Key Tasks for Residents:**
+    1. **Consent the Patient:** Use standard consent protocols. Ensure the patient (or guardian, if a child) signs. If an interpreter is used, document their information on the form.
+    2. **Stickers:** Place patient identification stickers on both the front and back of the form.
+    3. **Physician/Extension Initials:** Ensure the patient initials the section next to the text identifying the residents/physician extenders who will be in the case.
+- **Signatures:** You sign as the authorized representative. Place the completed consent in the patient's physical folder. The attending will sign it later.
+- **Timing:** Aim to complete consents **30 minutes before the case**. Attendings care to various degrees about this and reportedly can get flagged if it's done later. Dr. Lee is particularly strict about the 30-minute window.
+- **Epic Documentation:** Go to **Tasks** → **Consents** → click **Completed** → check **On Paper**.
+
+## Site Marking & H&Ps
+
+### Site Marking
+
+- Can be done physically with a marking pen or virtually (digital site marking) in Epic.
+- **Virtual Marking:** Done for laryngology/transoral procedures involving mucosal surfaces. Personal version based on the standard phrase is **.ASHALTSITE.**
+- **Pediatrics:** Children typically get virtual site markings.
+- **Exceptions:** Neurotologists strictly require the ears to be **physically marked** for cases like ear tubes or tonsils.
+
+### H&Ps (History & Physicals)
+
+- Use the Epic smartphrase: **.ENTPREOPHP.**
+- Requires inputting the planned procedure and the indication, which can be found in the most recent progress note.
+- **Finding Notes:** If the patient is not in the standard system, check the **Media** tab (e.g., cosmetic patients of Dr. Lee or private practice Atrius patients for pediatric attendings like Dr. Scott).
+- **Pitfall Warning: Always cross-reference the progress note with the case booking.** They do not always match.
+    - *Example:* Dr. Scott may book a case as a "BMT and adenoidectomy," but the progress note might state: *"Examination of ears, possible replacement of right ear tube, possible patch myringoplasty, possible adenoidectomy if Flonase doesn't improve symptoms."* **The consent must reflect what is in the progress note.** Notify the scrub tech and circulating nurse if extra equipment (like a microscope or tubes) is needed based on this discrepancy.
+- **Pro-Tip:** Ask the family to verbally confirm what procedure they are expecting to ensure it lines up.
+- **Workflow:** Prep and pend the site markings and H&Ps the night before, save the consent to a flash drive, and print them in the workroom in the morning. Keep them in your back pocket. Hand all consents to the attending to sign at once during or after the first case.
+- **Make sure to update the timestamp of H&Ps and site markings to the day of surgery when you sign them.**
+- **Attestation:** The attending must complete an attestation for the "S" to be checked off in pre-op. Dr. Scott is occasionally late due to morning grand rounds at MGH, so keep an eye on this.
+
+## Procedure-Specific Guides
+
+### 1. Myringotomy & Tube Placement (BMT)
+
+#### Room & Equipment Setup
+
+- **Microscope:** Must be balanced. Turn it on to ensure it works, verify eyepieces are zeroed, and confirm the rubber gaskets are intact on both the operating and observer eyepieces.
+- **Instruments:** Speculum, curette, 5-French suction (and a 3-Suction for advanced tube pushing), myringotomy blade, alligator forceps, pick, and the actual tubes (Sheehy or Armstrong).
+
+#### Intraoperative Flow
+
+1. **Anesthesia:** Mask ventilation is typically used for standalone tube placements; no intubation is required unless combined with an adenoidectomy/tonsillectomy.
+2. **Microscope Positioning:** Bring the microscope to the patient's waist (usually starting on the right side). For combined BMT/Adenoid cases, the microscope goes at the head of the bed, and the patient is turned 90° toward the anesthesia machine.
+3. **Cleaning:** Insert the speculum. Use a curette and 5-French suction to clear cerumen.
+4. **Incision (Myringotomy):** Make an **anterior-inferior** incision. Can do more inferior for better exposure.
+    - **Sheehy Tubes (Flexible silicone):** Require a larger incision (2.5 to 3 blade widths, or nearly umbo-to-annulus in some kids) because they are highly flexible and slippery.
+    - **Armstrong Tubes (Stiff):** Used at Rhode Island; require a smaller incision (1.5 to 2 blade widths) because they are stiffer and can stretch the tissue.
+5. **Bleeding Management:** If the blade dings the middle ear mucosa and causes bleeding:
+    - Suction it out and check if it stops.
+    - Apply **Afrin** drops and let it sit.
+    - If it continues, blindly but precisely place the tube into the bleeding field; the tube itself will act as a tamponade.
+6. **Tube Insertion:** Hook the bottom flange of the tube into the myringotomy incision. Steady your hand by resting the pick/instrument on the speculum and bracing your pinky/fourth finger on the patient's head. Push on the junction of the flange and tube body closest to you to pop it in.
+7. **Final Checks & Drops:** Orient the tube with a pick so you can see straight down the shaft to confirm patency. Add **1-2 drops of Ofloxacin** first so air doesn't get trapped, tap them in (or push the tragus), then add the remaining drops. Dr. V likes to see a bubble rise through the lumen to confirm it is patent. Place a cotton ball in the ear canal.
+
+#### Tube Replacement & Patch Myringoplasty
+
+- **Replacement:** Use a pick to free the old tube from the tympanic membrane, pop it out, retrieve it with alligator forceps, and place a new tube in the existing hole.
+- **Patch Myringoplasty (Dr. Scott):** Take a small piece of gelfoam and place it directly over the myringotomy hole.
+
+#### Post-Op Drops Schedule
+
+- **No Effusion:** 3 drops, 3x a day for **3 days**.
+- **Mucoid Effusion:** 3 drops, 3x a day for **5 days**.
+- **More Severe Effusion:** 3 drops, 3x a day for **7 days**.
+
+### 2. Tonsillectomy & Adenoidectomy (T&A)
+
+#### Room & Equipment Setup
+
+- **Patient Positioning:** Intubated, tube midline and taped to the bottom lip. Patient turned slightly past 90° toward the anesthesia machine.
+- **Pre-Prep Items to Grab:**
+    - **2 Blue Towels:** Grab these from the scrub tech to place behind the kid's head for head-wrapping.
+    - **Tape:** To secure the blue towels.
+    - **Shoulder Roll:** Size depends on the child.
+    - **Headlight.**
+
+#### Intraoperative Flow
+
+1. **Positioning:** Turn the child's head toward you. Have anesthesia lift the head while you assist with the ET tube, slide the blue towels underneath, place the shoulder roll, and wrap the head with tape.
+2. **Crowe-Davis Mouth Gag:** Insert midline, slowly walking it back on the tongue while keeping the tongue strictly midline. You can use a **Herd** retractor to assist. Expand the gag and suspend it on the Mayo stand.
+3. **Anatomy Check:** Palpate for a cleft palate immediately after suspending. (Dr. Scott doesn't really believe in this).
+4. **Tonsillectomy:** Grab the tonsil with a tonsil clamp, pull it medially to define the plane, and dissect. Electrocautery settings vary by attending (check their specific dot phrases).
+5. **Adenoidectomy:** Place a pediatric NG tube through the mouth and pull it out through the mouth (Dr. Scott puts a rolled piece of gauze over the columella to protect it before clamping).
+    - Dr. Scott uses a **microdebrider** (he will likely handle this for your first few cases).
+    - Dr. Vicky uses a **suction cautery**.
+6. **Hemostasis:** Irrigate and cauterize as needed until fully hemostatic, then remove the NG tube and Crowe-Davis.
+
+## Daily Flow & Tips for Being Efficient
+
+1. **Morning:** Sign H&Ps and site markings in Epic before morning rounds.
+2. **Pre-Op:** Consent the first patient immediately after rounds. If subsequent patients are already present, consent them sequentially to save time later.
+3. **In the OR:** Double-check the room setup (especially if the scrub tech is new). Keep your blue towels, shoulder roll, tape, and headlight ready for T&As.
+4. **Closing the Case:** While the patient is being emerged by anesthesia, complete your Epic documentation (**Op Note, Discharge Orders, Discharge Instructions**). Set the preferred pharmacy to **Atrium 3** before signing orders.
+5. **Sign-Out:** Deliver your PACU sign-out to the nurse (anticipating any questions they might have regarding post-op pain management, bleeding, or drops) and move immediately to pre-op the next patient.
+6. **Tips for Dr. Scott:** If you are pulled away from a case to cover something else, write his orders, write his discharge paperwork, and leave the physical consents directly in the OR. He really appreciates it.
+
+[Back to homepage](../index.html)


### PR DESCRIPTION
## Summary
This PR adds a comprehensive OR orientation guide documenting procedures, workflows, and best practices for residents in the ENT operating room. The new guide is integrated into the orientation documentation structure.

## Key Changes
- **New file:** `orientation/or-orientation.md` - A detailed 100-line orientation guide covering:
  - Pre-op and consent processes with timing requirements and Epic documentation steps
  - Site marking procedures (physical vs. virtual) and H&P documentation using Epic smartphrases
  - Procedure-specific guides for myringotomy & tube placement (BMT) including equipment setup, intraoperative flow, tube types, and post-op drop schedules
  - Tonsillectomy & adenoidectomy (T&A) procedures with positioning, equipment, and hemostasis techniques
  - Daily workflow tips for efficiency and attending-specific preferences
  
- **Updated:** `orientation/index.md` - Added link to the new OR orientation guide

- **Updated:** `index.md` - Added link to the new OR orientation guide in the main navigation

## Notable Details
The guide includes practical, procedure-specific information such as:
- Attending-specific preferences (Dr. Lee's strict 30-minute consent window, Dr. Scott's patch myringoplasty technique, Dr. Vicky's suction cautery approach)
- Equipment specifications (Sheehy vs. Armstrong tube incision sizes, microscope setup requirements)
- Critical safety checks (cross-referencing progress notes with case bookings, palpating for cleft palate)
- Efficiency tips for managing multiple cases and supporting attending physicians

https://claude.ai/code/session_01B1zhP3rDhcMyXjBUavGWfF